### PR TITLE
Add backend routes and frontend integration for events, swipe, and messages

### DIFF
--- a/back-end/README.md
+++ b/back-end/README.md
@@ -1,6 +1,6 @@
 # InternBuddy Back-End
 
-Express.js back-end scaffold focused on the signup -> profile pipeline.
+Express.js back-end for the InternBuddy application.
 
 ## Folder structure
 
@@ -13,64 +13,100 @@ back-end/
     server.js
     controllers/
       authController.js
+      eventsController.js
+      messagesController.js
       profileController.js
+      swipeController.js
     data/
       profileStepOrder.js
     middleware/
       errorHandlers.js
     routes/
       authRoutes.js
+      eventsRoutes.js
+      messagesRoutes.js
       profileRoutes.js
+      swipeRoutes.js
     services/
       mockStore.js
   test/
     authRoutes.test.js
+    eventsRoutes.test.js
+    messagesRoutes.test.js
     profileRoutes.test.js
+    swipeRoutes.test.js
   package.json
 ```
 
 ## Setup
 
-1. Open terminal in `back-end`.
+1. Open terminal in `back-end/`.
 2. Install dependencies:
-   - `npm install`
-3. Start server:
-   - `npm run dev`
+   ```bash
+   npm install
+   ```
+3. Create a `.env` file (see `.env.example` if available) — do **not** commit this file.
+4. Start the server:
+   ```bash
+   npm run dev
+   ```
+   The server runs on `http://localhost:3001` by default.
 
 ## Test and coverage
 
-- Run tests with coverage:
-  - `npm test`
-- Coverage reports:
-  - terminal summary
-  - `back-end/coverage/index.html`
+Run tests with coverage:
 
-## Mock API routes
+```bash
+npm test
+```
+
+Coverage reports:
+- Terminal summary printed after tests
+- HTML report at `back-end/coverage/index.html`
+
+## API Routes
 
 ### Static route
 
-- `GET /` -> returns `public/index.html`
+- `GET /` — serves `public/index.html`
 
-### Health route
+### Health
 
-- `GET /api/health`
+- `GET /api/health` — returns `{ status: "ok" }`
 
-### Auth routes
+### Auth routes (`/api/auth`)
 
-- `POST /api/auth/signup`
-  - body: `{ "email": "...", "phone": "..." }`
-- `POST /api/auth/verify`
-  - body: `{ "userId": "...", "code": "123456" }`
-- `GET /api/auth/:userId`
+- `POST /api/auth/signup` — body: `{ "email": "...", "phone": "..." }`
+- `POST /api/auth/verify` — body: `{ "userId": "...", "code": "123456" }`
+- `GET /api/auth/:userId` — get account by userId
 
-### Profile routes
+### Profile routes (`/api/profile`)
 
-- `GET /api/profile/:userId`
-- `POST /api/profile/:userId/step`
-  - body: `{ "step": "name", "value": { ... } }`
-- `POST /api/profile/:userId/complete`
+- `GET /api/profile/:userId` — get profile
+- `POST /api/profile/:userId/step` — body: `{ "step": "name", "value": { ... } }`
+- `POST /api/profile/:userId/complete` — mark profile complete
+
+### Events routes (`/api/events`)
+
+- `GET /api/events` — list all events
+- `GET /api/events/me` — get current user's events (hosting, attending, private, suggested)
+- `GET /api/events/:id` — get single event by id
+- `POST /api/events` — body: `{ "title": "...", "description": "...", "location": "...", "date": "...", "time": "...", "privacy": "public" }`
+
+### Swipe routes (`/api/swipe`)
+
+- `GET /api/swipe/profiles` — list swipeable profiles
+- `POST /api/swipe/like` — body: `{ "profileId": 1 }`
+- `POST /api/swipe/pass` — body: `{ "profileId": 1 }`
+- `GET /api/swipe/requests` — get sent and received friend requests
+
+### Messages routes (`/api/messages`)
+
+- `GET /api/messages` — list all conversations
+- `GET /api/messages/:conversationId` — get conversation with messages
+- `POST /api/messages/:conversationId` — body: `{ "text": "..." }`
 
 ## Notes
 
-- Current implementation uses in-memory mock data only.
+- Current implementation uses in-memory mock data — data resets on server restart.
 - Do not commit secrets; store sensitive values in `.env` files.

--- a/back-end/src/app.js
+++ b/back-end/src/app.js
@@ -4,6 +4,9 @@ const cors = require('cors');
 
 const authRoutes = require('./routes/authRoutes');
 const profileRoutes = require('./routes/profileRoutes');
+const eventsRoutes = require('./routes/eventsRoutes');
+const swipeRoutes = require('./routes/swipeRoutes');
+const messagesRoutes = require('./routes/messagesRoutes');
 const { notFoundHandler, errorHandler } = require('./middleware/errorHandlers');
 
 const app = express();
@@ -24,6 +27,9 @@ app.get('/api/health', (req, res) => {
 
 app.use('/api/auth', authRoutes);
 app.use('/api/profile', profileRoutes);
+app.use('/api/events', eventsRoutes);
+app.use('/api/swipe', swipeRoutes);
+app.use('/api/messages', messagesRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/back-end/src/controllers/eventsController.js
+++ b/back-end/src/controllers/eventsController.js
@@ -1,0 +1,30 @@
+const mockStore = require('../services/mockStore');
+
+function getAllEvents(req, res) {
+  const events = mockStore.getEvents();
+  res.json(events);
+}
+
+function getEventById(req, res) {
+  const event = mockStore.getEventById(req.params.id);
+  if (!event) {
+    return res.status(404).json({ error: 'Event not found' });
+  }
+  res.json(event);
+}
+
+function getUserEvents(req, res) {
+  const data = mockStore.getUserEvents();
+  res.json(data);
+}
+
+function createEvent(req, res) {
+  const { title } = req.body;
+  if (!title) {
+    return res.status(400).json({ error: 'Title is required' });
+  }
+  const event = mockStore.createEvent(req.body);
+  res.status(201).json(event);
+}
+
+module.exports = { getAllEvents, getEventById, getUserEvents, createEvent };

--- a/back-end/src/controllers/messagesController.js
+++ b/back-end/src/controllers/messagesController.js
@@ -1,0 +1,25 @@
+const mockStore = require('../services/mockStore');
+
+function getConversations(req, res) {
+  const conversations = mockStore.getConversations();
+  res.json(conversations);
+}
+
+function getMessages(req, res) {
+  const data = mockStore.getMessages(req.params.conversationId);
+  if (!data) {
+    return res.status(404).json({ error: 'Conversation not found' });
+  }
+  res.json(data);
+}
+
+function sendMessage(req, res) {
+  const { text } = req.body;
+  if (!text) {
+    return res.status(400).json({ error: 'text is required' });
+  }
+  const message = mockStore.sendMessage(req.params.conversationId, text);
+  res.status(201).json(message);
+}
+
+module.exports = { getConversations, getMessages, sendMessage };

--- a/back-end/src/controllers/swipeController.js
+++ b/back-end/src/controllers/swipeController.js
@@ -1,0 +1,31 @@
+const mockStore = require('../services/mockStore');
+
+function getProfiles(req, res) {
+  const profiles = mockStore.getSwipeProfiles();
+  res.json(profiles);
+}
+
+function likeProfile(req, res) {
+  const { profileId } = req.body;
+  if (!profileId) {
+    return res.status(400).json({ error: 'profileId is required' });
+  }
+  const result = mockStore.likeProfile(profileId);
+  res.json(result);
+}
+
+function passProfile(req, res) {
+  const { profileId } = req.body;
+  if (!profileId) {
+    return res.status(400).json({ error: 'profileId is required' });
+  }
+  const result = mockStore.passProfile(profileId);
+  res.json(result);
+}
+
+function getRequests(req, res) {
+  const requests = mockStore.getSwipeRequests();
+  res.json(requests);
+}
+
+module.exports = { getProfiles, likeProfile, passProfile, getRequests };

--- a/back-end/src/routes/eventsRoutes.js
+++ b/back-end/src/routes/eventsRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const { getAllEvents, getEventById, getUserEvents, createEvent } = require('../controllers/eventsController');
+
+router.get('/', getAllEvents);
+router.get('/me', getUserEvents);
+router.get('/:id', getEventById);
+router.post('/', createEvent);
+
+module.exports = router;

--- a/back-end/src/routes/messagesRoutes.js
+++ b/back-end/src/routes/messagesRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { getConversations, getMessages, sendMessage } = require('../controllers/messagesController');
+
+router.get('/', getConversations);
+router.get('/:conversationId', getMessages);
+router.post('/:conversationId', sendMessage);
+
+module.exports = router;

--- a/back-end/src/routes/swipeRoutes.js
+++ b/back-end/src/routes/swipeRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const { getProfiles, likeProfile, passProfile, getRequests } = require('../controllers/swipeController');
+
+router.get('/profiles', getProfiles);
+router.post('/like', likeProfile);
+router.post('/pass', passProfile);
+router.get('/requests', getRequests);
+
+module.exports = router;

--- a/back-end/src/services/mockStore.js
+++ b/back-end/src/services/mockStore.js
@@ -5,6 +5,229 @@ const profiles = new Map();
 
 let nextId = 1;
 
+// ── Events mock data ──
+const events = [
+  {
+    id: 'e1',
+    title: 'Intern Sushi Night',
+    description: 'All-you-can-eat sushi with fellow interns in the city!',
+    time: '7:00 PM',
+    date: '2026-05-15',
+    location: '123 Broadway, New York, NY',
+    privacy: 'public',
+    createdBy: 'u1',
+  },
+  {
+    id: 'e2',
+    title: 'Central Park Picnic',
+    description: 'Bring a blanket and snacks — let\'s hang out in the park.',
+    time: '12:00 PM',
+    date: '2026-05-18',
+    location: 'Sheep Meadow, Central Park, NY',
+    privacy: 'public',
+    createdBy: 'u2',
+  },
+  {
+    id: 'e3',
+    title: 'Rooftop Game Night',
+    description: 'Board games, card games, and good vibes on a rooftop.',
+    time: '8:00 PM',
+    date: '2026-05-20',
+    location: '456 W 42nd St, New York, NY',
+    privacy: 'public',
+    createdBy: 'u1',
+  },
+  {
+    id: 'e4',
+    title: 'Coffee & Code',
+    description: 'Casual co-working session at a cafe. Bring your laptop!',
+    time: '10:00 AM',
+    date: '2026-05-22',
+    location: 'Blue Bottle Coffee, Williamsburg, NY',
+    privacy: 'public',
+    createdBy: 'u3',
+  },
+  {
+    id: 'e5',
+    title: 'Sunset Run Club',
+    description: 'Easy 3-mile run along the Hudson River at sunset.',
+    time: '6:30 PM',
+    date: '2026-05-25',
+    location: 'Hudson River Park, Pier 40, NY',
+    privacy: 'public',
+    createdBy: 'u2',
+  },
+  {
+    id: 'e6',
+    title: 'Intern Karaoke Night',
+    description: 'Sing your heart out — no judgment zone!',
+    time: '9:00 PM',
+    date: '2026-05-28',
+    location: '789 St Marks Pl, New York, NY',
+    privacy: 'public',
+    createdBy: 'u3',
+  },
+];
+let nextEventId = 7;
+
+const userEvents = {
+  hosting: [
+    { id: 'h1', title: 'Sushi Night', date: 'June 12' },
+    { id: 'h2', title: 'Movie Night', date: 'June 19' },
+  ],
+  attending: [
+    { id: 'a1', title: 'Central Park Picnic', date: 'June 15' },
+    { id: 'a2', title: 'Rooftop Happy Hour', date: 'June 22' },
+  ],
+  private: [
+    { id: 'p1', title: 'Alex & Friends Dinner', host: 'Alex Chen', date: 'June 14' },
+    { id: 'p2', title: 'Priya Study Session', host: 'Priya S.', date: 'June 17' },
+  ],
+  suggested: [
+    { id: 's1', title: 'Intern Mixer NYC', date: 'June 20' },
+    { id: 's2', title: 'Tech Talk @ WeWork', date: 'June 25' },
+    { id: 's3', title: 'Brooklyn Foodie Tour', date: 'June 28' },
+  ],
+};
+
+// ── Swipe mock data ──
+const swipeProfiles = [
+  {
+    id: 1,
+    name: 'Sarah',
+    age: 21,
+    major: 'Data Science @ UC Berkeley',
+    internshipFull: 'Data Science Intern @ Google',
+    locationFull: 'San Francisco, CA | May – Aug 2026',
+    about: 'I love data, coffee, and exploring new neighborhoods. Excited to meet other interns this summer!',
+    pronouns: 'she/her',
+    image: 'https://picsum.photos/seed/profile1/400/500',
+    interests: ['Music', 'Food', 'Reading', 'Art'],
+    drinks: 'Socially',
+  },
+  {
+    id: 2,
+    name: 'Jessica',
+    age: 22,
+    major: 'Computer Science @ Stanford',
+    internshipFull: 'Software Engineer Intern @ Meta',
+    locationFull: 'San Francisco, CA | May – Aug 2026',
+    about: 'Full-stack developer, startup enthusiast, love hiking and trying new restaurants around the Bay.',
+    pronouns: 'she/her',
+    image: 'https://picsum.photos/seed/profile2/400/500',
+    interests: ['Sports', 'Party', 'Creation', 'Cafes'],
+    drinks: 'Yes',
+  },
+  {
+    id: 3,
+    name: 'Alex',
+    age: 23,
+    major: 'Electrical Engineering @ MIT',
+    internshipFull: 'Product Manager Intern @ Apple',
+    locationFull: 'San Francisco, CA | May – Aug 2026',
+    about: "I love building products that matter. When I'm not working, you can find me at concerts or reading sci-fi.",
+    pronouns: 'they/them',
+    image: 'https://picsum.photos/seed/profile3/400/500',
+    interests: ['Music', 'Creation', 'Reading', 'Swimming'],
+    drinks: 'No',
+  },
+  {
+    id: 4,
+    name: 'Elena',
+    age: 20,
+    major: 'UX/UI Design @ Cal Poly',
+    internshipFull: 'UX Designer Intern @ Adobe',
+    locationFull: 'San Francisco, CA | May – Aug 2026',
+    about: 'Design lover and coffee enthusiast. I enjoy sketching, photography, and meeting creative people!',
+    pronouns: 'she/her',
+    image: 'https://picsum.photos/seed/profile4/400/500',
+    interests: ['Food', 'Creation', 'Drinks', 'Photography'],
+    drinks: 'Socially',
+  },
+  {
+    id: 5,
+    name: 'Morgan',
+    age: 22,
+    major: 'Computer Science @ UCSC',
+    internshipFull: 'Backend Engineer Intern @ Stripe',
+    locationFull: 'San Francisco, CA | May – Aug 2026',
+    about: 'Backend optimization nerd, weekend athlete, and always down for a good game night.',
+    pronouns: 'he/him',
+    image: 'https://picsum.photos/seed/profile5/400/500',
+    interests: ['Sports', 'Reading', 'Music', 'Gaming'],
+    drinks: 'Socially',
+  },
+];
+
+const swipeLikes = [];
+const swipePasses = [];
+
+const receivedRequests = [
+  { id: 1, name: 'Priya S.', role: 'Design Intern @ Figma', image: 'https://picsum.photos/seed/priya/100/100' },
+  { id: 2, name: 'Jordan K.', role: 'PM Intern @ Stripe', image: 'https://picsum.photos/seed/jordan/100/100' },
+];
+
+// ── Messages mock data ──
+const conversations = [
+  {
+    id: 'c1',
+    otherUser: {
+      id: 'u2',
+      name: 'John Green',
+      username: 'jgreen',
+      avatar: 'https://picsum.photos/seed/jgreen/100/100',
+      subtitle: 'SWE Intern @ Google',
+    },
+    lastMessage: "Sounds good, let's figure something out this week.",
+    timestamp: '2h',
+    unreadCount: 1,
+  },
+  {
+    id: 'c2',
+    otherUser: {
+      id: 'u3',
+      name: 'Elon Musk',
+      username: 'emusk',
+      avatar: 'https://picsum.photos/seed/emusk/100/100',
+      subtitle: 'PM Intern @ Amazon',
+    },
+    lastMessage: "I'm down to grab coffee after work.",
+    timestamp: '1d',
+    unreadCount: 0,
+  },
+  {
+    id: 'c3',
+    otherUser: {
+      id: 'u4',
+      name: 'Andy Jassy',
+      username: 'ajassy',
+      avatar: 'https://picsum.photos/seed/ajassy/100/100',
+      subtitle: 'CS @ NYU',
+    },
+    lastMessage: 'Are you going to the intern meetup?',
+    timestamp: '3d',
+    unreadCount: 0,
+  },
+];
+
+const messagesByConversation = {
+  c1: [
+    { id: 1, sender: 'them', text: 'Hey! Are you free later this week?' },
+    { id: 2, sender: 'me', text: "Yeah probably, what's up?" },
+    { id: 3, sender: 'them', text: 'Wanted to grab coffee and talk internships.' },
+    { id: 4, sender: 'me', text: "I'm down." },
+    { id: 5, sender: 'them', text: "Sounds good, let's figure something out this week." },
+  ],
+  c2: [
+    { id: 1, sender: 'them', text: 'Hey! Saw you are interning in NYC too.' },
+    { id: 2, sender: 'me', text: 'Yeah! Where are you working?' },
+    { id: 3, sender: 'them', text: "I'm down to grab coffee after work." },
+  ],
+  c3: [
+    { id: 1, sender: 'them', text: 'Are you going to the intern meetup?' },
+  ],
+};
+
 function createAccount({ email, phone }) {
   const userId = String(nextId++);
   const account = {
@@ -76,11 +299,103 @@ function completeProfile(userId) {
   return profile;
 }
 
+// ── Events functions ──
+function getEvents() {
+  return events;
+}
+
+function getEventById(id) {
+  return events.find(e => e.id === id) || null;
+}
+
+function getUserEvents() {
+  return userEvents;
+}
+
+function createEvent({ title, description, location, date, time, privacy }) {
+  const newEvent = {
+    id: 'e' + nextEventId++,
+    title,
+    description: description || '',
+    location: location || '',
+    date: date || '',
+    time: time || '',
+    privacy: privacy || 'public',
+    createdBy: 'u1',
+  };
+  events.unshift(newEvent);
+  return newEvent;
+}
+
+// ── Swipe functions ──
+function getSwipeProfiles() {
+  return swipeProfiles;
+}
+
+function likeProfile(profileId) {
+  swipeLikes.push(profileId);
+  return { liked: profileId };
+}
+
+function passProfile(profileId) {
+  swipePasses.push(profileId);
+  return { passed: profileId };
+}
+
+function getSwipeRequests() {
+  return { received: receivedRequests, sent: swipeLikes };
+}
+
+// ── Messages functions ──
+function getConversations() {
+  return conversations;
+}
+
+function getMessages(conversationId) {
+  const convo = conversations.find(c => c.id === conversationId);
+  if (!convo) return null;
+  return {
+    conversation: convo,
+    messages: messagesByConversation[conversationId] || [],
+  };
+}
+
+function sendMessage(conversationId, text) {
+  if (!messagesByConversation[conversationId]) {
+    messagesByConversation[conversationId] = [];
+  }
+  const msgs = messagesByConversation[conversationId];
+  const newMsg = {
+    id: msgs.length + 1,
+    sender: 'me',
+    text,
+  };
+  msgs.push(newMsg);
+
+  const convo = conversations.find(c => c.id === conversationId);
+  if (convo) {
+    convo.lastMessage = text;
+    convo.timestamp = 'now';
+  }
+  return newMsg;
+}
+
 module.exports = {
   createAccount,
   getAccount,
   verifyAccount,
   saveProfileStep,
   getProfile,
-  completeProfile
+  completeProfile,
+  getEvents,
+  getEventById,
+  getUserEvents,
+  createEvent,
+  getSwipeProfiles,
+  likeProfile,
+  passProfile,
+  getSwipeRequests,
+  getConversations,
+  getMessages,
+  sendMessage,
 };

--- a/back-end/test/eventsRoutes.test.js
+++ b/back-end/test/eventsRoutes.test.js
@@ -1,0 +1,55 @@
+const chai = require('chai');
+const expect = chai.expect;
+const request = require('supertest');
+const app = require('../src/app');
+
+describe('Events Routes', () => {
+  it('GET /api/events should return an array of events', async () => {
+    const res = await request(app).get('/api/events');
+    expect(res.status).to.equal(200);
+    expect(res.body).to.be.an('array');
+    expect(res.body.length).to.be.greaterThan(0);
+    expect(res.body[0]).to.have.property('title');
+    expect(res.body[0]).to.have.property('id');
+  });
+
+  it('GET /api/events/:id should return a single event', async () => {
+    const res = await request(app).get('/api/events/e1');
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('id', 'e1');
+    expect(res.body).to.have.property('title');
+  });
+
+  it('GET /api/events/:id should return 404 for unknown id', async () => {
+    const res = await request(app).get('/api/events/e999');
+    expect(res.status).to.equal(404);
+    expect(res.body).to.have.property('error');
+  });
+
+  it('POST /api/events should create a new event', async () => {
+    const res = await request(app)
+      .post('/api/events')
+      .send({ title: 'Test Event', location: 'NYC', date: '2026-06-01', time: '5:00 PM' });
+    expect(res.status).to.equal(201);
+    expect(res.body).to.have.property('id');
+    expect(res.body).to.have.property('title', 'Test Event');
+    expect(res.body).to.have.property('location', 'NYC');
+  });
+
+  it('GET /api/events/me should return user events with all categories', async () => {
+    const res = await request(app).get('/api/events/me');
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('hosting').that.is.an('array');
+    expect(res.body).to.have.property('attending').that.is.an('array');
+    expect(res.body).to.have.property('private').that.is.an('array');
+    expect(res.body).to.have.property('suggested').that.is.an('array');
+  });
+
+  it('POST /api/events should return 400 without title', async () => {
+    const res = await request(app)
+      .post('/api/events')
+      .send({ location: 'NYC' });
+    expect(res.status).to.equal(400);
+    expect(res.body).to.have.property('error');
+  });
+});

--- a/back-end/test/messagesRoutes.test.js
+++ b/back-end/test/messagesRoutes.test.js
@@ -1,0 +1,49 @@
+const chai = require('chai');
+const expect = chai.expect;
+const request = require('supertest');
+const app = require('../src/app');
+
+describe('Messages Routes', () => {
+  it('GET /api/messages should return an array of conversations', async () => {
+    const res = await request(app).get('/api/messages');
+    expect(res.status).to.equal(200);
+    expect(res.body).to.be.an('array');
+    expect(res.body.length).to.be.greaterThan(0);
+    expect(res.body[0]).to.have.property('id');
+    expect(res.body[0]).to.have.property('otherUser');
+    expect(res.body[0]).to.have.property('lastMessage');
+  });
+
+  it('GET /api/messages/:conversationId should return conversation and messages', async () => {
+    const res = await request(app).get('/api/messages/c1');
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('conversation');
+    expect(res.body).to.have.property('messages');
+    expect(res.body.messages).to.be.an('array');
+    expect(res.body.messages.length).to.be.greaterThan(0);
+  });
+
+  it('GET /api/messages/:conversationId should return 404 for unknown id', async () => {
+    const res = await request(app).get('/api/messages/c999');
+    expect(res.status).to.equal(404);
+    expect(res.body).to.have.property('error');
+  });
+
+  it('POST /api/messages/:conversationId should send a message', async () => {
+    const res = await request(app)
+      .post('/api/messages/c1')
+      .send({ text: 'Hello from test!' });
+    expect(res.status).to.equal(201);
+    expect(res.body).to.have.property('id');
+    expect(res.body).to.have.property('sender', 'me');
+    expect(res.body).to.have.property('text', 'Hello from test!');
+  });
+
+  it('POST /api/messages/:conversationId should return 400 without text', async () => {
+    const res = await request(app)
+      .post('/api/messages/c1')
+      .send({});
+    expect(res.status).to.equal(400);
+    expect(res.body).to.have.property('error');
+  });
+});

--- a/back-end/test/swipeRoutes.test.js
+++ b/back-end/test/swipeRoutes.test.js
@@ -1,0 +1,47 @@
+const chai = require('chai');
+const expect = chai.expect;
+const request = require('supertest');
+const app = require('../src/app');
+
+describe('Swipe Routes', () => {
+  it('GET /api/swipe/profiles should return an array of profiles', async () => {
+    const res = await request(app).get('/api/swipe/profiles');
+    expect(res.status).to.equal(200);
+    expect(res.body).to.be.an('array');
+    expect(res.body.length).to.be.greaterThan(0);
+    expect(res.body[0]).to.have.property('name');
+    expect(res.body[0]).to.have.property('internshipFull');
+  });
+
+  it('POST /api/swipe/like should record a like', async () => {
+    const res = await request(app)
+      .post('/api/swipe/like')
+      .send({ profileId: 1 });
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('liked', 1);
+  });
+
+  it('POST /api/swipe/pass should record a pass', async () => {
+    const res = await request(app)
+      .post('/api/swipe/pass')
+      .send({ profileId: 2 });
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('passed', 2);
+  });
+
+  it('POST /api/swipe/like should return 400 without profileId', async () => {
+    const res = await request(app)
+      .post('/api/swipe/like')
+      .send({});
+    expect(res.status).to.equal(400);
+    expect(res.body).to.have.property('error');
+  });
+
+  it('GET /api/swipe/requests should return received and sent', async () => {
+    const res = await request(app).get('/api/swipe/requests');
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('received');
+    expect(res.body).to.have.property('sent');
+    expect(res.body.received).to.be.an('array');
+  });
+});

--- a/front-end/src/context/EventsContext.jsx
+++ b/front-end/src/context/EventsContext.jsx
@@ -1,5 +1,4 @@
 import { createContext, useState, useEffect } from 'react'
-import { faker } from '@faker-js/faker'
 
 export const EventsContext = createContext()
 
@@ -7,19 +6,21 @@ export function EventsProvider({ children }) {
   const [events, setEvents] = useState([])
 
   useEffect(() => {
-    const fakeEvents = Array.from({ length: 6 }, (_, i) => ({
-      id: i,
-      title: faker.company.catchPhrase(),
-      description: faker.lorem.sentence(),
-      time: faker.date.soon().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-      date: faker.date.soon().toLocaleDateString(),
-      location: `${faker.location.streetAddress()}, ${faker.location.city()}`,
-    }))
-    setEvents(fakeEvents)
+    fetch('/api/events')
+      .then(res => res.json())
+      .then(data => setEvents(data))
+      .catch(err => console.error('Failed to fetch events:', err))
   }, [])
 
   const addEvent = (newEvent) => {
-    setEvents(prev => [{ ...newEvent, id: Date.now() }, ...prev])
+    fetch('/api/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(newEvent),
+    })
+      .then(res => res.json())
+      .then(created => setEvents(prev => [created, ...prev]))
+      .catch(err => console.error('Failed to create event:', err))
   }
 
   return (
@@ -28,4 +29,3 @@ export function EventsProvider({ children }) {
     </EventsContext.Provider>
   )
 }
-

--- a/front-end/src/pages/DirectMessagePage.jsx
+++ b/front-end/src/pages/DirectMessagePage.jsx
@@ -1,25 +1,41 @@
-import { useNavigate } from "react-router-dom";
-
-const conversation = {
-  id: "c1",
-  otherUser: {
-    id: "u2",
-    name: "John Green",
-    username: "jgreen",
-    avatar: "https://picsum.photos/seed/jgreen/100/100",
-    subtitle: "SWE Intern @ Google",
-  },
-};
-
-const messages = [
-  { id: 1, sender: "them", text: "Hey! Are you free later this week?" },
-  { id: 2, sender: "me", text: "Yeah probably, what’s up?" },
-  { id: 3, sender: "them", text: "Wanted to grab coffee and talk internships." },
-  { id: 4, sender: "me", text: "I’m down." },
-];
+import { useState, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 
 export default function DirectMessagePage() {
   const navigate = useNavigate();
+  const { id } = useParams();
+  const [conversation, setConversation] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [newText, setNewText] = useState("");
+
+  useEffect(() => {
+    fetch(`/api/messages/${id}`)
+      .then(res => res.json())
+      .then(data => {
+        setConversation(data.conversation);
+        setMessages(data.messages);
+      })
+      .catch(err => console.error('Failed to fetch messages:', err));
+  }, [id]);
+
+  const handleSend = (e) => {
+    e.preventDefault();
+    if (!newText.trim()) return;
+
+    fetch(`/api/messages/${id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: newText }),
+    })
+      .then(res => res.json())
+      .then(msg => {
+        setMessages(prev => [...prev, msg]);
+        setNewText("");
+      })
+      .catch(err => console.error('Failed to send message:', err));
+  };
+
+  if (!conversation) return null;
 
   return (
     <div className="min-h-screen bg-[#eeeef8] p-4">
@@ -72,22 +88,23 @@ export default function DirectMessagePage() {
           ))}
         </div>
 
-        {/* Input (disabled) */}
-        <div className="p-4 border-t border-gray-100">
+        {/* Input */}
+        <form onSubmit={handleSend} className="p-4 border-t border-gray-100">
           <div className="flex items-center gap-2 bg-gray-50 border border-gray-200 rounded-xl px-3 py-2">
             <input
-              disabled
-              placeholder="Messaging coming soon..."
-              className="flex-1 bg-transparent text-sm text-gray-400 outline-none"
+              value={newText}
+              onChange={(e) => setNewText(e.target.value)}
+              placeholder="Type a message..."
+              className="flex-1 bg-transparent text-sm text-gray-900 outline-none"
             />
             <button
-              disabled
-              className="text-xs text-gray-400"
+              type="submit"
+              className="text-xs text-indigo-600 font-semibold"
             >
               Send
             </button>
           </div>
-        </div>
+        </form>
 
       </div>
     </div>

--- a/front-end/src/pages/MessagesPage.jsx
+++ b/front-end/src/pages/MessagesPage.jsx
@@ -1,60 +1,21 @@
+import { useState, useEffect } from "react";
 import ConversationList from "../components/ConversationList";
 
-const mockConversations = [
-  {
-    id: "c1",
-    otherUser: {
-      id: "u2",
-      name: "John Green",
-      username: "jgreen",
-      avatar: "https://picsum.photos/seed/jgreen/100/100",
-      subtitle: "SWE Intern @ Google",
-    },
-    lastMessage: "Sounds good, let’s figure something out this week.",
-    timestamp: "2h",
-    unreadCount: 1,
-  },
-//   {
-//     id: "c2",
-//     otherUser: {
-//       id: "u3",
-//       name: "Elon Musk",
-//       username: "emusk",
-//       avatar: "https://picsum.photos/seed/emusk/100/100",
-//       subtitle: "PM Intern @ Amazon",
-//     },
-//     lastMessage: "I’m down to grab coffee after work.",
-//     timestamp: "1d",
-//     unreadCount: 0,
-//   },
-//   {
-//     id: "c3",
-//     otherUser: {
-//       id: "u4",
-//       name: "Andy Jassy",
-//       username: "ajassy",
-//       avatar: "https://picsum.photos/seed/ajassy/100/100",
-//       subtitle: "CS @ NYU",
-//     },
-//     lastMessage: "Are you going to the intern meetup?",
-//     timestamp: "3d",
-//     unreadCount: 0,
-//   },
-];
-
 export default function MessagesPage() {
-    const handleConversationClick = (conversation) => {
-      console.log("Open conversation:", conversation.id);
-    };
-  
-    return (
-      <div className="flex justify-center">
-        <div className="max-w-[390px]">
-          <ConversationList
-            conversations={mockConversations}
-            onConversationClick={handleConversationClick}
-          />
-        </div>
+  const [conversations, setConversations] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/messages')
+      .then(res => res.json())
+      .then(data => setConversations(data))
+      .catch(err => console.error('Failed to fetch conversations:', err));
+  }, []);
+
+  return (
+    <div className="flex justify-center">
+      <div className="max-w-[390px]">
+        <ConversationList conversations={conversations} />
       </div>
-    );
-  }
+    </div>
+  );
+}

--- a/front-end/src/pages/SwipePage.jsx
+++ b/front-end/src/pages/SwipePage.jsx
@@ -1,98 +1,40 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import './SwipePage.css'
 
-const MOCK_PROFILES = [
-  {
-    id: 1,
-    name: 'Sarah',
-    age: 21,
-    major: 'Data Science @ UC Berkeley',
-    internshipFull: 'Data Science Intern @ Google',
-    locationFull: 'San Francisco, CA | May – Aug 2026',
-    about:
-      'I love data, coffee, and exploring new neighborhoods. Excited to meet other interns this summer!',
-    pronouns: 'she/her',
-    image: 'https://picsum.photos/seed/profile1/400/500',
-    interests: ['🎵 Music', '🍜 Food', '📚 Reading', '🎨 Art'],
-    drinks: 'Socially',
-  },
-  {
-    id: 2,
-    name: 'Jessica',
-    age: 22,
-    major: 'Computer Science @ Stanford',
-    internshipFull: 'Software Engineer Intern @ Meta',
-    locationFull: 'San Francisco, CA | May – Aug 2026',
-    about:
-      "Full-stack developer, startup enthusiast, love hiking and trying new restaurants around the Bay.",
-    pronouns: 'she/her',
-    image: 'https://picsum.photos/seed/profile2/400/500',
-    interests: ['🏀 Sports', '🎉 Party', '🎨 Creation', '☕ Cafes'],
-    drinks: 'Yes',
-  },
-  {
-    id: 3,
-    name: 'Alex',
-    age: 23,
-    major: 'Electrical Engineering @ MIT',
-    internshipFull: 'Product Manager Intern @ Apple',
-    locationFull: 'San Francisco, CA | May – Aug 2026',
-    about:
-      "I love building products that matter. When I'm not working, you can find me at concerts or reading sci-fi.",
-    pronouns: 'they/them',
-    image: 'https://picsum.photos/seed/profile3/400/500',
-    interests: ['🎵 Music', '🎨 Creation', '📚 Reading', '🏊 Swimming'],
-    drinks: 'No',
-  },
-  {
-    id: 4,
-    name: 'Elena',
-    age: 20,
-    major: 'UX/UI Design @ Cal Poly',
-    internshipFull: 'UX Designer Intern @ Adobe',
-    locationFull: 'San Francisco, CA | May – Aug 2026',
-    about:
-      "Design lover and coffee enthusiast. I enjoy sketching, photography, and meeting creative people!",
-    pronouns: 'she/her',
-    image: 'https://picsum.photos/seed/profile4/400/500',
-    interests: ['🍜 Food', '🎨 Creation', '🍹 Drinks', '📷 Photography'],
-    drinks: 'Socially',
-  },
-  {
-    id: 5,
-    name: 'Morgan',
-    age: 22,
-    major: 'Computer Science @ UCSC',
-    internshipFull: 'Backend Engineer Intern @ Stripe',
-    locationFull: 'San Francisco, CA | May – Aug 2026',
-    about:
-      "Backend optimization nerd, weekend athlete, and always down for a good game night.",
-    pronouns: 'he/him',
-    image: 'https://picsum.photos/seed/profile5/400/500',
-    interests: ['🏀 Sports', '📚 Reading', '🎵 Music', '🎮 Gaming'],
-    drinks: 'Socially',
-  },
-]
-
 function SwipePage() {
+  const [profiles, setProfiles] = useState([])
   const [currentIndex, setCurrentIndex] = useState(0)
   const [notification, setNotification] = useState(null)
   const [swipeDirection, setSwipeDirection] = useState(null)
   const [sentRequests, setSentRequests] = useState([])
+  const [receivedRequests, setReceivedRequests] = useState([])
   const [showRequests, setShowRequests] = useState(false)
   const [requestsTab, setRequestsTab] = useState('received')
 
-  const mockReceivedRequests = [
-    { id: 1, name: 'Priya S.', role: 'Design Intern @ Figma', image: 'https://picsum.photos/seed/priya/100/100' },
-    { id: 2, name: 'Jordan K.', role: 'PM Intern @ Stripe', image: 'https://picsum.photos/seed/jordan/100/100' },
-  ]
+  useEffect(() => {
+    fetch('/api/swipe/profiles')
+      .then(res => res.json())
+      .then(data => setProfiles(data))
+      .catch(err => console.error('Failed to fetch profiles:', err))
 
-  const profile = MOCK_PROFILES[currentIndex]
+    fetch('/api/swipe/requests')
+      .then(res => res.json())
+      .then(data => setReceivedRequests(data.received || []))
+      .catch(err => console.error('Failed to fetch requests:', err))
+  }, [])
+
+  const profile = profiles[currentIndex]
 
   const handleReject = () => {
     setSwipeDirection('left')
+    fetch('/api/swipe/pass', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profileId: profile.id }),
+    }).catch(err => console.error('Failed to pass:', err))
+
     setTimeout(() => {
-      if (currentIndex < MOCK_PROFILES.length - 1) {
+      if (currentIndex < profiles.length - 1) {
         setCurrentIndex(currentIndex + 1)
         setNotification(null)
       } else {
@@ -106,8 +48,15 @@ function SwipePage() {
     setSwipeDirection('right')
     setSentRequests([...sentRequests, profile.name])
     setNotification({ type: 'success', text: `✓ Friend request sent to ${profile.name}!` })
+
+    fetch('/api/swipe/like', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profileId: profile.id }),
+    }).catch(err => console.error('Failed to like:', err))
+
     setTimeout(() => {
-      if (currentIndex < MOCK_PROFILES.length - 1) {
+      if (currentIndex < profiles.length - 1) {
         setCurrentIndex(currentIndex + 1)
         setNotification(null)
       } else {
@@ -122,9 +71,9 @@ function SwipePage() {
       <div className="swipe-top-bar">
         <button className="swipe-heart-btn" onClick={() => setShowRequests(true)}>
           ❤️
-          {(sentRequests.length + mockReceivedRequests.length) > 0 && (
+          {(sentRequests.length + receivedRequests.length) > 0 && (
             <span className="swipe-heart-badge">
-              {sentRequests.length + mockReceivedRequests.length}
+              {sentRequests.length + receivedRequests.length}
             </span>
           )}
         </button>
@@ -208,7 +157,7 @@ function SwipePage() {
                 }`}
                 onClick={() => setRequestsTab('received')}
               >
-                Received ({mockReceivedRequests.length})
+                Received ({receivedRequests.length})
               </button>
               <button
                 className={`swipe-requests-tab ${
@@ -222,8 +171,8 @@ function SwipePage() {
 
             <div className="swipe-requests-list">
               {requestsTab === 'received' &&
-                (mockReceivedRequests.length > 0 ? (
-                  mockReceivedRequests.map((req) => (
+                (receivedRequests.length > 0 ? (
+                  receivedRequests.map((req) => (
                     <div key={req.id} className="swipe-request-item">
                       <img
                         src={req.image}

--- a/front-end/src/pages/YourEventsPage.jsx
+++ b/front-end/src/pages/YourEventsPage.jsx
@@ -1,31 +1,18 @@
-import { useRef } from 'react'
+import { useRef, useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import './YourEventsPage.css'
-
-const hostingEvents = [
-  { id: 1, title: 'Sushi Night', date: 'June 12' },
-  { id: 2, title: 'Movie Night', date: 'June 19' },
-]
-
-const attendingEvents = [
-  { id: 1, title: 'Central Park Picnic', date: 'June 15' },
-  { id: 2, title: 'Rooftop Happy Hour', date: 'June 22' },
-]
-
-const privateEvents = [
-  { id: 1, title: 'Alex & Friends Dinner', host: 'Alex Chen', date: 'June 14' },
-  { id: 2, title: 'Priya Study Session', host: 'Priya S.', date: 'June 17' },
-]
-
-const suggestedEvents = [
-  { id: 1, title: 'Intern Mixer NYC', date: 'June 20' },
-  { id: 2, title: 'Tech Talk @ WeWork', date: 'June 25' },
-  { id: 3, title: 'Brooklyn Foodie Tour', date: 'June 28' },
-]
 
 export default function YourEventsPage() {
   const navigate = useNavigate()
   const privateRef = useRef(null)
+  const [data, setData] = useState({ hosting: [], attending: [], private: [], suggested: [] })
+
+  useEffect(() => {
+    fetch('/api/events/me')
+      .then(res => res.json())
+      .then(d => setData(d))
+      .catch(err => console.error('Failed to fetch your events:', err))
+  }, [])
 
   return (
     <div className="your-events-page">
@@ -37,7 +24,7 @@ export default function YourEventsPage() {
       <section className="ye-section">
         <h2 className="ye-section-title">Hosting</h2>
         <div className="ye-bubbles">
-          {hostingEvents.map(e => (
+          {data.hosting.map(e => (
             <div key={e.id} className="ye-bubble">
               <span className="ye-bubble-title">{e.title}</span>
               <span className="ye-bubble-date">{e.date}</span>
@@ -49,7 +36,7 @@ export default function YourEventsPage() {
       <section className="ye-section">
         <h2 className="ye-section-title">Attending</h2>
         <div className="ye-bubbles">
-          {attendingEvents.map(e => (
+          {data.attending.map(e => (
             <div key={e.id} className="ye-bubble">
               <span className="ye-bubble-title">{e.title}</span>
               <span className="ye-bubble-date">{e.date}</span>
@@ -61,7 +48,7 @@ export default function YourEventsPage() {
       <section className="ye-section" ref={privateRef}>
         <h2 className="ye-section-title">Private Events</h2>
         <div className="ye-bubbles">
-          {privateEvents.map(e => (
+          {data.private.map(e => (
             <div key={e.id} className="ye-bubble ye-bubble--private">
               <span className="ye-bubble-title">{e.title}</span>
               <span className="ye-bubble-host">from {e.host}</span>
@@ -74,7 +61,7 @@ export default function YourEventsPage() {
       <section className="ye-section">
         <h2 className="ye-section-title">Suggested For You</h2>
         <div className="ye-bubbles">
-          {suggestedEvents.map(e => (
+          {data.suggested.map(e => (
             <div key={e.id} className="ye-bubble ye-bubble--suggested">
               <span className="ye-bubble-title">{e.title}</span>
               <span className="ye-bubble-date">{e.date}</span>

--- a/front-end/vite.config.js
+++ b/front-end/vite.config.js
@@ -5,4 +5,9 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- Add Express.js backend routes, controllers, and mock data for **events** (CRUD + user events), **swipe** (profiles, like/pass, friend requests), and **messages** (conversations, DMs, send)
- Wire up frontend pages (`EventsContext`, `SwipePage`, `MessagesPage`, `DirectMessagePage`, `YourEventsPage`) to `fetch()` from `/api` instead of using hardcoded/faker data
- Enable working send-message functionality in `DirectMessagePage`
- Add Vite proxy config to forward `/api` requests to backend
- Add 16 unit tests (mocha/chai/supertest) covering all new routes — **89.75% code coverage**
- Update `back-end/README.md` with complete API route documentation

## What's left for teammates
- **SearchPage** — still uses `faker`, needs backend route + frontend fetch
- **Login/Auth pages** — frontend not wired to `/api/auth` endpoints
- **Settings/AccountCenter** — still uses static local data
- **ProfilePage** — has hardcoded `friendRequests`, `hostingEvents`, `attendingEvents`

## Test plan
- [ ] Run `cd back-end && npm test` — all 20 tests should pass with 89%+ coverage
- [ ] Run `cd back-end && npm start` then `cd front-end && npm run dev`
- [ ] Verify Events page loads events from backend
- [ ] Verify "Your Events" page shows hosting/attending/private/suggested from backend
- [ ] Verify Create Event form POSTs to backend and new event appears in list
- [ ] Verify Swipe page loads profiles from backend, like/pass POST correctly
- [ ] Verify Messages page loads conversations from backend
- [ ] Verify Direct Message page loads messages and send works

🤖 Generated with [Claude Code](https://claude.com/claude-code)