### PR TITLE
Feature/backend connections mock

### DIFF
--- a/back-end/src/app.js
+++ b/back-end/src/app.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 
 const authRoutes = require('./routes/authRoutes');
 const profileRoutes = require('./routes/profileRoutes');
+const connectionsRoutes = require('./routes/connectionsRoutes');
 const { notFoundHandler, errorHandler } = require('./middleware/errorHandlers');
 
 const app = express();
@@ -24,6 +25,8 @@ app.get('/api/health', (req, res) => {
 
 app.use('/api/auth', authRoutes);
 app.use('/api/profile', profileRoutes);
+
+app.use('/api/connections', connectionsRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/back-end/src/controllers/connectionsController.js
+++ b/back-end/src/controllers/connectionsController.js
@@ -2,7 +2,9 @@ const {
   addRequest,
   getPendingForUser,
   getAcceptedForUser,
-  acceptRequestById
+  acceptRequestById,
+  rejectRequestById,
+  deleteConnectionById
 } = require('../services/connectionsStore');
 
 function sendRequest(req, res) {
@@ -49,9 +51,39 @@ function acceptRequest(req, res) {
   });
 }
 
+function rejectRequest(req, res) {
+  const { requestId } = req.params;
+  const record = rejectRequestById(requestId);
+
+  if (!record) {
+    return res.status(404).json({ error: 'Connection request not found' });
+  }
+
+  return res.status(200).json({
+    message: 'Connection request rejected (mock)',
+    request: record
+  });
+}
+
+function deleteConnection(req, res) {
+  const { requestId } = req.params;
+  const record = deleteConnectionById(requestId);
+
+  if (!record) {
+    return res.status(404).json({ error: 'Connection not found' });
+  }
+
+  return res.status(200).json({
+    message: 'Connection deleted (mock)',
+    deleted: record
+  });
+}
+
 module.exports = {
   sendRequest,
   getPending,
   getAccepted,
-  acceptRequest
+  acceptRequest,
+  rejectRequest,
+  deleteConnection
 };

--- a/back-end/src/controllers/connectionsController.js
+++ b/back-end/src/controllers/connectionsController.js
@@ -1,6 +1,7 @@
 const {
   addRequest,
   getPendingForUser,
+  getSentForUser,
   getAcceptedForUser,
   acceptRequestById,
   rejectRequestById,
@@ -35,6 +36,12 @@ function getAccepted(req, res) {
   const { userId } = req.params;
   const accepted = getAcceptedForUser(userId);
   return res.status(200).json({ accepted });
+}
+
+function getSent(req, res) {
+  const { userId } = req.params;
+  const sent = getSentForUser(userId);
+  return res.status(200).json({ sent });
 }
 
 function acceptRequest(req, res) {
@@ -82,6 +89,7 @@ function deleteConnection(req, res) {
 module.exports = {
   sendRequest,
   getPending,
+  getSent,
   getAccepted,
   acceptRequest,
   rejectRequest,

--- a/back-end/src/controllers/connectionsController.js
+++ b/back-end/src/controllers/connectionsController.js
@@ -1,0 +1,23 @@
+const { addRequest } = require('../services/connectionsStore');
+
+function sendRequest(req, res) {
+  const { fromUserId, toUserId } = req.body;
+
+  if (!fromUserId || !toUserId) {
+    return res.status(400).json({
+      error: 'Missing required fields',
+      required: ['fromUserId', 'toUserId']
+    });
+  }
+
+  const record = addRequest(fromUserId, toUserId);
+
+  return res.status(201).json({
+    message: 'Connection request sent (mock)',
+    request: record
+  });
+}
+
+module.exports = {
+  sendRequest
+};

--- a/back-end/src/controllers/connectionsController.js
+++ b/back-end/src/controllers/connectionsController.js
@@ -7,6 +7,7 @@ const {
   rejectRequestById,
   deleteConnectionById
 } = require('../services/connectionsStore');
+const { getUserById } = require('../services/usersStore');
 
 function sendRequest(req, res) {
   const { fromUserId, toUserId } = req.body;
@@ -22,7 +23,7 @@ function sendRequest(req, res) {
 
   return res.status(201).json({
     message: 'Connection request sent (mock)',
-    request: record
+    request: { ...record, toUser: getUserById(toUserId) }
   });
 }
 

--- a/back-end/src/controllers/connectionsController.js
+++ b/back-end/src/controllers/connectionsController.js
@@ -1,7 +1,8 @@
 const {
   addRequest,
   getPendingForUser,
-  getAcceptedForUser
+  getAcceptedForUser,
+  acceptRequestById
 } = require('../services/connectionsStore');
 
 function sendRequest(req, res) {
@@ -34,8 +35,23 @@ function getAccepted(req, res) {
   return res.status(200).json({ accepted });
 }
 
+function acceptRequest(req, res) {
+  const { requestId } = req.params;
+  const record = acceptRequestById(requestId);
+
+  if (!record) {
+    return res.status(404).json({ error: 'Connection request not found' });
+  }
+
+  return res.status(200).json({
+    message: 'Connection request accepted (mock)',
+    request: record
+  });
+}
+
 module.exports = {
   sendRequest,
   getPending,
-  getAccepted
+  getAccepted,
+  acceptRequest
 };

--- a/back-end/src/controllers/connectionsController.js
+++ b/back-end/src/controllers/connectionsController.js
@@ -1,4 +1,8 @@
-const { addRequest } = require('../services/connectionsStore');
+const {
+  addRequest,
+  getPendingForUser,
+  getAcceptedForUser
+} = require('../services/connectionsStore');
 
 function sendRequest(req, res) {
   const { fromUserId, toUserId } = req.body;
@@ -18,6 +22,20 @@ function sendRequest(req, res) {
   });
 }
 
+function getPending(req, res) {
+  const { userId } = req.params;
+  const pending = getPendingForUser(userId);
+  return res.status(200).json({ pending });
+}
+
+function getAccepted(req, res) {
+  const { userId } = req.params;
+  const accepted = getAcceptedForUser(userId);
+  return res.status(200).json({ accepted });
+}
+
 module.exports = {
-  sendRequest
+  sendRequest,
+  getPending,
+  getAccepted
 };

--- a/back-end/src/routes/connectionsRoutes.js
+++ b/back-end/src/routes/connectionsRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const {
   sendRequest,
   getPending,
+  getSent,
   getAccepted,
   acceptRequest,
   rejectRequest,
@@ -12,6 +13,7 @@ const router = express.Router();
 
 router.post('/request', sendRequest);
 router.get('/:userId/pending', getPending);
+router.get('/:userId/sent', getSent);
 router.get('/:userId', getAccepted);
 router.post('/:requestId/accept', acceptRequest);
 router.post('/:requestId/reject', rejectRequest);

--- a/back-end/src/routes/connectionsRoutes.js
+++ b/back-end/src/routes/connectionsRoutes.js
@@ -2,7 +2,8 @@ const express = require('express');
 const {
   sendRequest,
   getPending,
-  getAccepted
+  getAccepted,
+  acceptRequest
 } = require('../controllers/connectionsController');
 
 const router = express.Router();
@@ -15,5 +16,6 @@ router.get('/ping', (req, res) => {
 router.post('/request', sendRequest);
 router.get('/:userId/pending', getPending);
 router.get('/:userId', getAccepted);
+router.post('/:requestId/accept', acceptRequest);
 
 module.exports = router;

--- a/back-end/src/routes/connectionsRoutes.js
+++ b/back-end/src/routes/connectionsRoutes.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { sendRequest } = require('../controllers/connectionsController');
 
 const router = express.Router();
 
@@ -6,5 +7,7 @@ const router = express.Router();
 router.get('/ping', (req, res) => {
   res.json({ message: 'connections route is alive' });
 });
+
+router.post('/request', sendRequest);
 
 module.exports = router;

--- a/back-end/src/routes/connectionsRoutes.js
+++ b/back-end/src/routes/connectionsRoutes.js
@@ -3,7 +3,9 @@ const {
   sendRequest,
   getPending,
   getAccepted,
-  acceptRequest
+  acceptRequest,
+  rejectRequest,
+  deleteConnection
 } = require('../controllers/connectionsController');
 
 const router = express.Router();
@@ -17,5 +19,7 @@ router.post('/request', sendRequest);
 router.get('/:userId/pending', getPending);
 router.get('/:userId', getAccepted);
 router.post('/:requestId/accept', acceptRequest);
+router.post('/:requestId/reject', rejectRequest);
+router.delete('/:requestId', deleteConnection);
 
 module.exports = router;

--- a/back-end/src/routes/connectionsRoutes.js
+++ b/back-end/src/routes/connectionsRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+
+const router = express.Router();
+
+// placeholder route to make sure wiring works
+router.get('/ping', (req, res) => {
+  res.json({ message: 'connections route is alive' });
+});
+
+module.exports = router;

--- a/back-end/src/routes/connectionsRoutes.js
+++ b/back-end/src/routes/connectionsRoutes.js
@@ -10,11 +10,6 @@ const {
 
 const router = express.Router();
 
-// placeholder route to make sure wiring works
-router.get('/ping', (req, res) => {
-  res.json({ message: 'connections route is alive' });
-});
-
 router.post('/request', sendRequest);
 router.get('/:userId/pending', getPending);
 router.get('/:userId', getAccepted);

--- a/back-end/src/routes/connectionsRoutes.js
+++ b/back-end/src/routes/connectionsRoutes.js
@@ -1,5 +1,9 @@
 const express = require('express');
-const { sendRequest } = require('../controllers/connectionsController');
+const {
+  sendRequest,
+  getPending,
+  getAccepted
+} = require('../controllers/connectionsController');
 
 const router = express.Router();
 
@@ -9,5 +13,7 @@ router.get('/ping', (req, res) => {
 });
 
 router.post('/request', sendRequest);
+router.get('/:userId/pending', getPending);
+router.get('/:userId', getAccepted);
 
 module.exports = router;

--- a/back-end/src/services/connectionsStore.js
+++ b/back-end/src/services/connectionsStore.js
@@ -51,6 +51,18 @@ function acceptRequestById(id) {
   return record;
 }
 
+function seedConnections() {
+  // user "3" sent a request to user "1" - incoming pending for user 1
+  addRequest('3', '1');
+  // user "4" sent a request to user "1" - another incoming pending
+  addRequest('4', '1');
+  // user "1" and user "2" are already friends
+  const req = addRequest('1', '2');
+  acceptRequestById(req.id);
+}
+
+seedConnections();
+
 function rejectRequestById(id) {
   const record = connections.get(id);
   if (!record) return null;
@@ -72,5 +84,6 @@ module.exports = {
   getAcceptedForUser,
   acceptRequestById,
   rejectRequestById,
-  deleteConnectionById
+  deleteConnectionById,
+  seedConnections
 };

--- a/back-end/src/services/connectionsStore.js
+++ b/back-end/src/services/connectionsStore.js
@@ -51,10 +51,26 @@ function acceptRequestById(id) {
   return record;
 }
 
+function rejectRequestById(id) {
+  const record = connections.get(id);
+  if (!record) return null;
+  record.status = 'rejected';
+  return record;
+}
+
+function deleteConnectionById(id) {
+  const record = connections.get(id);
+  if (!record) return null;
+  connections.delete(id);
+  return record;
+}
+
 module.exports = {
   connections,
   addRequest,
   getPendingForUser,
   getAcceptedForUser,
-  acceptRequestById
+  acceptRequestById,
+  rejectRequestById,
+  deleteConnectionById
 };

--- a/back-end/src/services/connectionsStore.js
+++ b/back-end/src/services/connectionsStore.js
@@ -60,6 +60,19 @@ function acceptRequestById(id) {
   return record;
 }
 
+function getSentForUser(userId) {
+  const results = [];
+  for (const record of connections.values()) {
+    if (record.fromUserId === userId && record.status === 'pending') {
+      results.push({
+        ...record,
+        toUser: getUserById(record.toUserId)
+      });
+    }
+  }
+  return results;
+}
+
 function seedConnections() {
   // user "3" sent a request to user "1" - incoming pending for user 1
   addRequest('3', '1');
@@ -90,6 +103,7 @@ module.exports = {
   connections,
   addRequest,
   getPendingForUser,
+  getSentForUser,
   getAcceptedForUser,
   acceptRequestById,
   rejectRequestById,

--- a/back-end/src/services/connectionsStore.js
+++ b/back-end/src/services/connectionsStore.js
@@ -20,7 +20,30 @@ function addRequest(fromUserId, toUserId) {
   return record;
 }
 
+function getPendingForUser(userId) {
+  const results = [];
+  for (const record of connections.values()) {
+    if (record.toUserId === userId && record.status === 'pending') {
+      results.push(record);
+    }
+  }
+  return results;
+}
+
+function getAcceptedForUser(userId) {
+  const results = [];
+  for (const record of connections.values()) {
+    if (record.status !== 'accepted') continue;
+    if (record.fromUserId === userId || record.toUserId === userId) {
+      results.push(record);
+    }
+  }
+  return results;
+}
+
 module.exports = {
   connections,
-  addRequest
+  addRequest,
+  getPendingForUser,
+  getAcceptedForUser
 };

--- a/back-end/src/services/connectionsStore.js
+++ b/back-end/src/services/connectionsStore.js
@@ -1,0 +1,13 @@
+// in-memory store for friend connections
+// each connection looks like:
+// { id, fromUserId, toUserId, status, createdAt }
+// status is one of: 'pending', 'accepted', 'rejected'
+
+const connections = new Map();
+
+let nextId = 1;
+
+module.exports = {
+  connections,
+  nextId
+};

--- a/back-end/src/services/connectionsStore.js
+++ b/back-end/src/services/connectionsStore.js
@@ -41,9 +41,20 @@ function getAcceptedForUser(userId) {
   return results;
 }
 
+function acceptRequestById(id) {
+  const record = connections.get(id);
+  if (!record) {
+    return null;
+  }
+  record.status = 'accepted';
+  record.acceptedAt = new Date().toISOString();
+  return record;
+}
+
 module.exports = {
   connections,
   addRequest,
   getPendingForUser,
-  getAcceptedForUser
+  getAcceptedForUser,
+  acceptRequestById
 };

--- a/back-end/src/services/connectionsStore.js
+++ b/back-end/src/services/connectionsStore.js
@@ -7,7 +7,20 @@ const connections = new Map();
 
 let nextId = 1;
 
+function addRequest(fromUserId, toUserId) {
+  const id = String(nextId++);
+  const record = {
+    id,
+    fromUserId,
+    toUserId,
+    status: 'pending',
+    createdAt: new Date().toISOString()
+  };
+  connections.set(id, record);
+  return record;
+}
+
 module.exports = {
   connections,
-  nextId
+  addRequest
 };

--- a/back-end/src/services/connectionsStore.js
+++ b/back-end/src/services/connectionsStore.js
@@ -3,6 +3,8 @@
 // { id, fromUserId, toUserId, status, createdAt }
 // status is one of: 'pending', 'accepted', 'rejected'
 
+const { getUserById } = require('./usersStore');
+
 const connections = new Map();
 
 let nextId = 1;
@@ -24,7 +26,10 @@ function getPendingForUser(userId) {
   const results = [];
   for (const record of connections.values()) {
     if (record.toUserId === userId && record.status === 'pending') {
-      results.push(record);
+      results.push({
+        ...record,
+        fromUser: getUserById(record.fromUserId)
+      });
     }
   }
   return results;
@@ -35,7 +40,11 @@ function getAcceptedForUser(userId) {
   for (const record of connections.values()) {
     if (record.status !== 'accepted') continue;
     if (record.fromUserId === userId || record.toUserId === userId) {
-      results.push(record);
+      const otherUserId = record.fromUserId === userId ? record.toUserId : record.fromUserId;
+      results.push({
+        ...record,
+        otherUser: getUserById(otherUserId)
+      });
     }
   }
   return results;

--- a/back-end/src/services/usersStore.js
+++ b/back-end/src/services/usersStore.js
@@ -1,0 +1,13 @@
+// mock user profiles - just enough data to display in the connections UI
+const users = new Map([
+  ['1', { id: '1', name: 'Alissa', role: 'SWE Intern @ Airbnb', image: 'https://picsum.photos/seed/user1/100/100' }],
+  ['2', { id: '2', name: 'John Green', role: 'SWE Intern @ Google', image: 'https://picsum.photos/seed/user2/100/100' }],
+  ['3', { id: '3', name: 'Priya S.', role: 'Design Intern @ Figma', image: 'https://picsum.photos/seed/user3/100/100' }],
+  ['4', { id: '4', name: 'Jordan K.', role: 'PM Intern @ Stripe', image: 'https://picsum.photos/seed/user4/100/100' }],
+]);
+
+function getUserById(id) {
+  return users.get(id) || { id, name: 'Unknown User', role: '', image: 'https://picsum.photos/seed/unknown/100/100' };
+}
+
+module.exports = { getUserById };

--- a/back-end/src/services/usersStore.js
+++ b/back-end/src/services/usersStore.js
@@ -1,9 +1,14 @@
 // mock user profiles - just enough data to display in the connections UI
 const users = new Map([
-  ['1', { id: '1', name: 'Alissa', role: 'SWE Intern @ Airbnb', image: 'https://picsum.photos/seed/user1/100/100' }],
+  ['1', { id: '1', name: 'Lisa', role: 'SWE Intern @ Airbnb', image: 'https://picsum.photos/seed/user1/100/100' }],
   ['2', { id: '2', name: 'John Green', role: 'SWE Intern @ Google', image: 'https://picsum.photos/seed/user2/100/100' }],
   ['3', { id: '3', name: 'Priya S.', role: 'Design Intern @ Figma', image: 'https://picsum.photos/seed/user3/100/100' }],
   ['4', { id: '4', name: 'Jordan K.', role: 'PM Intern @ Stripe', image: 'https://picsum.photos/seed/user4/100/100' }],
+  ['101', { id: '101', name: 'Sarah', role: 'Data Science Intern @ Google', image: 'https://picsum.photos/seed/profile1/100/100' }],
+  ['102', { id: '102', name: 'Jessica', role: 'SWE Intern @ Meta', image: 'https://picsum.photos/seed/profile2/100/100' }],
+  ['103', { id: '103', name: 'Alex', role: 'PM Intern @ Apple', image: 'https://picsum.photos/seed/profile3/100/100' }],
+  ['104', { id: '104', name: 'Elena', role: 'UX Design Intern @ Adobe', image: 'https://picsum.photos/seed/profile4/100/100' }],
+  ['105', { id: '105', name: 'Morgan', role: 'Backend Intern @ Stripe', image: 'https://picsum.photos/seed/profile5/100/100' }],
 ]);
 
 function getUserById(id) {

--- a/back-end/test/connectionsRoutes.test.js
+++ b/back-end/test/connectionsRoutes.test.js
@@ -53,6 +53,27 @@ describe('Connections routes', () => {
     });
   });
 
+  describe('GET /api/connections/:userId/sent', () => {
+    it('should return sent pending requests for a user', async () => {
+      const send = await request(app)
+        .post('/api/connections/request')
+        .send({ fromUserId: '50', toUserId: '51' });
+
+      const res = await request(app).get('/api/connections/50/sent');
+
+      expect(res.status).to.equal(200);
+      expect(res.body.sent).to.be.an('array');
+      expect(res.body.sent.length).to.be.at.least(1);
+      expect(res.body.sent[0]).to.have.property('toUser');
+    });
+
+    it('should return empty array for user with no sent requests', async () => {
+      const res = await request(app).get('/api/connections/999/sent');
+      expect(res.status).to.equal(200);
+      expect(res.body.sent).to.deep.equal([]);
+    });
+  });
+
   describe('GET /api/connections/:userId', () => {
     it('should return accepted connections for a user', async () => {
       // user 1 has a seeded accepted connection with user 2

--- a/back-end/test/connectionsRoutes.test.js
+++ b/back-end/test/connectionsRoutes.test.js
@@ -1,0 +1,123 @@
+const request = require('supertest');
+const { expect } = require('chai');
+
+const app = require('../src/app');
+
+describe('Connections routes', () => {
+
+  describe('POST /api/connections/request', () => {
+    it('should send a connection request and return 201', async () => {
+      const res = await request(app)
+        .post('/api/connections/request')
+        .send({ fromUserId: '10', toUserId: '11' });
+
+      expect(res.status).to.equal(201);
+      expect(res.body.request).to.have.property('id');
+      expect(res.body.request.status).to.equal('pending');
+      expect(res.body.request.fromUserId).to.equal('10');
+      expect(res.body.request.toUserId).to.equal('11');
+    });
+
+    it('should return 400 if fromUserId is missing', async () => {
+      const res = await request(app)
+        .post('/api/connections/request')
+        .send({ toUserId: '11' });
+
+      expect(res.status).to.equal(400);
+    });
+
+    it('should return 400 if toUserId is missing', async () => {
+      const res = await request(app)
+        .post('/api/connections/request')
+        .send({ fromUserId: '10' });
+
+      expect(res.status).to.equal(400);
+    });
+  });
+
+  describe('GET /api/connections/:userId/pending', () => {
+    it('should return pending requests for a user', async () => {
+      // user 1 has seeded pending requests from users 3 and 4
+      const res = await request(app).get('/api/connections/1/pending');
+
+      expect(res.status).to.equal(200);
+      expect(res.body.pending).to.be.an('array');
+      expect(res.body.pending.length).to.be.at.least(1);
+    });
+
+    it('should return empty array for user with no pending requests', async () => {
+      const res = await request(app).get('/api/connections/999/pending');
+
+      expect(res.status).to.equal(200);
+      expect(res.body.pending).to.deep.equal([]);
+    });
+  });
+
+  describe('GET /api/connections/:userId', () => {
+    it('should return accepted connections for a user', async () => {
+      // user 1 has a seeded accepted connection with user 2
+      const res = await request(app).get('/api/connections/1');
+
+      expect(res.status).to.equal(200);
+      expect(res.body.accepted).to.be.an('array');
+      expect(res.body.accepted.length).to.be.at.least(1);
+    });
+  });
+
+  describe('POST /api/connections/:requestId/accept', () => {
+    it('should accept a pending request', async () => {
+      // first send a new request so we have an id to accept
+      const send = await request(app)
+        .post('/api/connections/request')
+        .send({ fromUserId: '20', toUserId: '21' });
+
+      const requestId = send.body.request.id;
+
+      const res = await request(app).post(`/api/connections/${requestId}/accept`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.request.status).to.equal('accepted');
+    });
+
+    it('should return 404 if request does not exist', async () => {
+      const res = await request(app).post('/api/connections/9999/accept');
+      expect(res.status).to.equal(404);
+    });
+  });
+
+  describe('POST /api/connections/:requestId/reject', () => {
+    it('should reject a pending request', async () => {
+      const send = await request(app)
+        .post('/api/connections/request')
+        .send({ fromUserId: '30', toUserId: '31' });
+
+      const requestId = send.body.request.id;
+
+      const res = await request(app).post(`/api/connections/${requestId}/reject`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.request.status).to.equal('rejected');
+    });
+  });
+
+  describe('DELETE /api/connections/:requestId', () => {
+    it('should delete a connection', async () => {
+      const send = await request(app)
+        .post('/api/connections/request')
+        .send({ fromUserId: '40', toUserId: '41' });
+
+      const requestId = send.body.request.id;
+
+      const res = await request(app).delete(`/api/connections/${requestId}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.deleted).to.have.property('id', requestId);
+    });
+
+    it('should return 404 if connection does not exist', async () => {
+      const res = await request(app).delete('/api/connections/9999');
+      expect(res.status).to.equal(404);
+    });
+  });
+
+});

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import { EventsProvider } from './context/EventsContext'
 import { ProfileProvider } from './context/ProfileContext'
+import { ConnectionsProvider } from './context/ConnectionsContext'
 import LoginPage from './pages/LoginPage'
 import ForgotPasswordPage from './pages/ForgotPasswordPage'
 import CreateAccountEmailPage from './pages/CreateAccountEmailPage'
@@ -39,6 +40,7 @@ function App() {
   return (
     <EventsProvider>
       <ProfileProvider>
+      <ConnectionsProvider>
         <Router>
           <Routes>
           <Route path="/" element={<LoginPage />} />
@@ -75,6 +77,7 @@ function App() {
           </Routes>
           <BottomNav />
         </Router>
+      </ConnectionsProvider>
       </ProfileProvider>
     </EventsProvider>
   )

--- a/front-end/src/context/ConnectionsContext.jsx
+++ b/front-end/src/context/ConnectionsContext.jsx
@@ -7,12 +7,17 @@ const MY_USER_ID = '1'
 
 export function ConnectionsProvider({ children }) {
   const [pending, setPending] = useState([])
+  const [sent, setSent] = useState([])
   const [accepted, setAccepted] = useState([])
 
   useEffect(() => {
     fetch(`/api/connections/${MY_USER_ID}/pending`)
       .then(res => res.json())
       .then(data => setPending(data.pending))
+
+    fetch(`/api/connections/${MY_USER_ID}/sent`)
+      .then(res => res.json())
+      .then(data => setSent(data.sent))
 
     fetch(`/api/connections/${MY_USER_ID}`)
       .then(res => res.json())
@@ -24,7 +29,12 @@ export function ConnectionsProvider({ children }) {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ fromUserId: MY_USER_ID, toUserId })
-    }).then(res => res.json())
+    })
+      .then(res => res.json())
+      .then(data => {
+        setSent(prev => [...prev, data.request])
+        return data
+      })
   }
 
   function acceptRequest(requestId) {
@@ -47,10 +57,14 @@ export function ConnectionsProvider({ children }) {
   function cancelRequest(requestId) {
     return fetch(`/api/connections/${requestId}`, { method: 'DELETE' })
       .then(res => res.json())
+      .then(data => {
+        setSent(prev => prev.filter(r => r.id !== requestId))
+        return data
+      })
   }
 
   return (
-    <ConnectionsContext.Provider value={{ pending, accepted, sendRequest, acceptRequest, rejectRequest, cancelRequest }}>
+    <ConnectionsContext.Provider value={{ pending, sent, accepted, sendRequest, acceptRequest, rejectRequest, cancelRequest }}>
       {children}
     </ConnectionsContext.Provider>
   )

--- a/front-end/src/context/ConnectionsContext.jsx
+++ b/front-end/src/context/ConnectionsContext.jsx
@@ -1,0 +1,52 @@
+import { createContext, useState, useEffect } from 'react'
+
+export const ConnectionsContext = createContext()
+
+// hardcoded for now since we don't have real auth yet
+const MY_USER_ID = '1'
+
+export function ConnectionsProvider({ children }) {
+  const [pending, setPending] = useState([])
+  const [accepted, setAccepted] = useState([])
+
+  useEffect(() => {
+    fetch(`/api/connections/${MY_USER_ID}/pending`)
+      .then(res => res.json())
+      .then(data => setPending(data.pending))
+
+    fetch(`/api/connections/${MY_USER_ID}`)
+      .then(res => res.json())
+      .then(data => setAccepted(data.accepted))
+  }, [])
+
+  function sendRequest(toUserId) {
+    return fetch('/api/connections/request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fromUserId: MY_USER_ID, toUserId })
+    }).then(res => res.json())
+  }
+
+  function acceptRequest(requestId) {
+    return fetch(`/api/connections/${requestId}/accept`, { method: 'POST' })
+      .then(res => res.json())
+      .then(data => {
+        setPending(prev => prev.filter(r => r.id !== requestId))
+        setAccepted(prev => [...prev, data.request])
+      })
+  }
+
+  function rejectRequest(requestId) {
+    return fetch(`/api/connections/${requestId}/reject`, { method: 'POST' })
+      .then(res => res.json())
+      .then(() => {
+        setPending(prev => prev.filter(r => r.id !== requestId))
+      })
+  }
+
+  return (
+    <ConnectionsContext.Provider value={{ pending, accepted, sendRequest, acceptRequest, rejectRequest }}>
+      {children}
+    </ConnectionsContext.Provider>
+  )
+}

--- a/front-end/src/context/ConnectionsContext.jsx
+++ b/front-end/src/context/ConnectionsContext.jsx
@@ -44,8 +44,13 @@ export function ConnectionsProvider({ children }) {
       })
   }
 
+  function cancelRequest(requestId) {
+    return fetch(`/api/connections/${requestId}`, { method: 'DELETE' })
+      .then(res => res.json())
+  }
+
   return (
-    <ConnectionsContext.Provider value={{ pending, accepted, sendRequest, acceptRequest, rejectRequest }}>
+    <ConnectionsContext.Provider value={{ pending, accepted, sendRequest, acceptRequest, rejectRequest, cancelRequest }}>
       {children}
     </ConnectionsContext.Provider>
   )

--- a/front-end/src/pages/SwipePage.jsx
+++ b/front-end/src/pages/SwipePage.jsx
@@ -76,11 +76,10 @@ const MOCK_PROFILES = [
 ]
 
 function SwipePage() {
-  const { pending, sendRequest, acceptRequest, rejectRequest } = useContext(ConnectionsContext)
+  const { pending, sent, sendRequest, acceptRequest, rejectRequest } = useContext(ConnectionsContext)
   const [currentIndex, setCurrentIndex] = useState(0)
   const [notification, setNotification] = useState(null)
   const [swipeDirection, setSwipeDirection] = useState(null)
-  const [sentRequests, setSentRequests] = useState([])
   const [showRequests, setShowRequests] = useState(false)
   const [requestsTab, setRequestsTab] = useState('received')
 
@@ -101,7 +100,6 @@ function SwipePage() {
 
   const handleAccept = () => {
     setSwipeDirection('right')
-    setSentRequests([...sentRequests, profile.name])
     sendRequest(String(profile.id))
     setNotification({ type: 'success', text: `✓ Friend request sent to ${profile.name}!` })
     setTimeout(() => {
@@ -120,9 +118,9 @@ function SwipePage() {
       <div className="swipe-top-bar">
         <button className="swipe-heart-btn" onClick={() => setShowRequests(true)}>
           ❤️
-          {(sentRequests.length + pending.length) > 0 && (
+          {(sent.length + pending.length) > 0 && (
             <span className="swipe-heart-badge">
-              {sentRequests.length + pending.length}
+              {sent.length + pending.length}
             </span>
           )}
         </button>
@@ -214,7 +212,7 @@ function SwipePage() {
                 }`}
                 onClick={() => setRequestsTab('sent')}
               >
-                Sent ({sentRequests.length})
+                Sent ({sent.length})
               </button>
             </div>
 
@@ -243,11 +241,11 @@ function SwipePage() {
                 ))}
 
               {requestsTab === 'sent' &&
-                (sentRequests.length > 0 ? (
-                  sentRequests.map((name, index) => (
-                    <div key={index} className="swipe-sent-request-item">
+                (sent.length > 0 ? (
+                  sent.map((req) => (
+                    <div key={req.id} className="swipe-sent-request-item">
                       <div className="swipe-sent-request-info">
-                        <h3>{name}</h3>
+                        <h3>{req.toUser ? req.toUser.name : `User ${req.toUserId}`}</h3>
                         <p>Request sent</p>
                       </div>
                       <span className="swipe-sent-request-badge">⏳</span>

--- a/front-end/src/pages/SwipePage.jsx
+++ b/front-end/src/pages/SwipePage.jsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useContext } from 'react'
+import { ConnectionsContext } from '../context/ConnectionsContext'
 import './SwipePage.css'
 
 const MOCK_PROFILES = [
@@ -75,17 +76,13 @@ const MOCK_PROFILES = [
 ]
 
 function SwipePage() {
+  const { pending, sendRequest, acceptRequest, rejectRequest } = useContext(ConnectionsContext)
   const [currentIndex, setCurrentIndex] = useState(0)
   const [notification, setNotification] = useState(null)
   const [swipeDirection, setSwipeDirection] = useState(null)
   const [sentRequests, setSentRequests] = useState([])
   const [showRequests, setShowRequests] = useState(false)
   const [requestsTab, setRequestsTab] = useState('received')
-
-  const mockReceivedRequests = [
-    { id: 1, name: 'Priya S.', role: 'Design Intern @ Figma', image: 'https://picsum.photos/seed/priya/100/100' },
-    { id: 2, name: 'Jordan K.', role: 'PM Intern @ Stripe', image: 'https://picsum.photos/seed/jordan/100/100' },
-  ]
 
   const profile = MOCK_PROFILES[currentIndex]
 
@@ -105,6 +102,7 @@ function SwipePage() {
   const handleAccept = () => {
     setSwipeDirection('right')
     setSentRequests([...sentRequests, profile.name])
+    sendRequest(String(profile.id))
     setNotification({ type: 'success', text: `✓ Friend request sent to ${profile.name}!` })
     setTimeout(() => {
       if (currentIndex < MOCK_PROFILES.length - 1) {
@@ -122,9 +120,9 @@ function SwipePage() {
       <div className="swipe-top-bar">
         <button className="swipe-heart-btn" onClick={() => setShowRequests(true)}>
           ❤️
-          {(sentRequests.length + mockReceivedRequests.length) > 0 && (
+          {(sentRequests.length + pending.length) > 0 && (
             <span className="swipe-heart-badge">
-              {sentRequests.length + mockReceivedRequests.length}
+              {sentRequests.length + pending.length}
             </span>
           )}
         </button>
@@ -208,7 +206,7 @@ function SwipePage() {
                 }`}
                 onClick={() => setRequestsTab('received')}
               >
-                Received ({mockReceivedRequests.length})
+                Received ({pending.length})
               </button>
               <button
                 className={`swipe-requests-tab ${
@@ -222,21 +220,21 @@ function SwipePage() {
 
             <div className="swipe-requests-list">
               {requestsTab === 'received' &&
-                (mockReceivedRequests.length > 0 ? (
-                  mockReceivedRequests.map((req) => (
+                (pending.length > 0 ? (
+                  pending.map((req) => (
                     <div key={req.id} className="swipe-request-item">
                       <img
-                        src={req.image}
-                        alt={req.name}
+                        src={req.fromUser.image}
+                        alt={req.fromUser.name}
                         className="swipe-request-image"
                       />
                       <div className="swipe-request-info">
-                        <h3>{req.name}</h3>
-                        <p>{req.role}</p>
+                        <h3>{req.fromUser.name}</h3>
+                        <p>{req.fromUser.role}</p>
                       </div>
                       <div className="swipe-request-actions">
-                        <button className="swipe-request-accept">✓</button>
-                        <button className="swipe-request-reject">✕</button>
+                        <button className="swipe-request-accept" onClick={() => acceptRequest(req.id)}>✓</button>
+                        <button className="swipe-request-reject" onClick={() => rejectRequest(req.id)}>✕</button>
                       </div>
                     </div>
                   ))

--- a/front-end/src/pages/SwipePage.jsx
+++ b/front-end/src/pages/SwipePage.jsx
@@ -4,7 +4,7 @@ import './SwipePage.css'
 
 const MOCK_PROFILES = [
   {
-    id: 1,
+    id: 101,
     name: 'Sarah',
     age: 21,
     major: 'Data Science @ UC Berkeley',
@@ -18,7 +18,7 @@ const MOCK_PROFILES = [
     drinks: 'Socially',
   },
   {
-    id: 2,
+    id: 102,
     name: 'Jessica',
     age: 22,
     major: 'Computer Science @ Stanford',
@@ -32,7 +32,7 @@ const MOCK_PROFILES = [
     drinks: 'Yes',
   },
   {
-    id: 3,
+    id: 103,
     name: 'Alex',
     age: 23,
     major: 'Electrical Engineering @ MIT',
@@ -46,7 +46,7 @@ const MOCK_PROFILES = [
     drinks: 'No',
   },
   {
-    id: 4,
+    id: 104,
     name: 'Elena',
     age: 20,
     major: 'UX/UI Design @ Cal Poly',
@@ -60,7 +60,7 @@ const MOCK_PROFILES = [
     drinks: 'Socially',
   },
   {
-    id: 5,
+    id: 105,
     name: 'Morgan',
     age: 22,
     major: 'Computer Science @ UCSC',

--- a/front-end/src/pages/searchPage/searchPage.jsx
+++ b/front-end/src/pages/searchPage/searchPage.jsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useContext } from 'react'
 import { faker } from '@faker-js/faker'
+import { ConnectionsContext } from '../../context/ConnectionsContext'
 import SwipePage from '../SwipePage'
 import './searchPage.css'
 
@@ -31,12 +32,19 @@ function Degreebadge({ degree }) {
   return <span className={`sp-degree sp-degree--${degree}`}>{labels[degree]}</span>
 }
 
-function PersonCard({ person, onConnect }) {
+function PersonCard({ person, onConnect, onCancel }) {
   const [status, setStatus] = useState(person.connected ? 'connected' : 'idle')
+  const [requestId, setRequestId] = useState(null)
 
   const handleConnect = () => {
     setStatus('pending')
-    onConnect(person.id)
+    onConnect(person.id).then(data => setRequestId(data.request.id))
+  }
+
+  const handleCancel = () => {
+    onCancel(requestId)
+    setStatus('idle')
+    setRequestId(null)
   }
 
   return (
@@ -59,16 +67,17 @@ function PersonCard({ person, onConnect }) {
       </div>
       <button
         className={`sp-connect-btn sp-connect-btn--${status}`}
-        onClick={handleConnect}
-        disabled={status !== 'idle'}
+        onClick={status === 'pending' ? handleCancel : handleConnect}
+        disabled={status === 'connected'}
       >
-        {status === 'connected' ? 'Connected' : status === 'pending' ? 'Pending' : '+ Connect'}
+        {status === 'connected' ? 'Connected' : status === 'pending' ? 'Pending ✕' : '+ Connect'}
       </button>
     </div>
   )
 }
 
 export default function SearchPage() {
+  const { sendRequest, cancelRequest } = useContext(ConnectionsContext)
   const [people, setPeople] = useState([])
   const [swipeMode, setSwipeMode] = useState(false)
   const [query, setQuery] = useState('')
@@ -136,6 +145,11 @@ export default function SearchPage() {
 
   const handleConnect = (id) => {
     setPeople(prev => prev.map(p => p.id === id ? { ...p, connected: true } : p))
+    return sendRequest(String(id))
+  }
+
+  const handleCancel = (requestId) => {
+    cancelRequest(requestId)
   }
 
   if (swipeMode) {
@@ -200,7 +214,7 @@ export default function SearchPage() {
       <div className="sp-results">
         {results.length === 0
           ? <p className="sp-empty">No results. Try adjusting your filters.</p>
-          : results.map(p => <PersonCard key={p.id} person={p} onConnect={handleConnect} />)
+          : results.map(p => <PersonCard key={p.id} person={p} onConnect={handleConnect} onCancel={handleCancel} />)
         }
       </div>
 

--- a/front-end/src/pages/searchPage/searchPage.jsx
+++ b/front-end/src/pages/searchPage/searchPage.jsx
@@ -144,7 +144,6 @@ export default function SearchPage() {
   }, [people, query, applied, sortBy])
 
   const handleConnect = (id) => {
-    setPeople(prev => prev.map(p => p.id === id ? { ...p, connected: true } : p))
     return sendRequest(String(id))
   }
 

--- a/front-end/vite.config.js
+++ b/front-end/vite.config.js
@@ -5,4 +5,9 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
 })


### PR DESCRIPTION
Added Express back-end routes for friend connections (send, accept, reject, delete, get pending/sent/accepted)
Added mock in-memory store, added some seeded data so we can see how it would look
Wires SwipePage (swipe right) and SearchPage (+ Connect button) to real back-end
Added a connectionscontext middleman btwn the frontend and backend, fetches data from the backend on mount, exposes functions the UI can call, this is useful since without context, every compnent that needs connections data would have to fetch independently, and this way we fetch once on mount and share everywhere
Also added in functionality to unsend a request, on the search page
<img width="307" height="197" alt="Screenshot 2026-04-09 at 7 23 21 PM" src="https://github.com/user-attachments/assets/e7d22f46-1a71-4506-8007-658c22ba87ab" />
Some limitations we have is that we don't have real user data / IDs, so all the requests and such just show up as User 1, so this is a blocker to fully implement and check that this works