### PR TITLE
unified swipe/connection systems, removed the 'u' and 'doesn't have '…

### DIFF
--- a/back-end/src/controllers/swipeController.js
+++ b/back-end/src/controllers/swipeController.js
@@ -28,4 +28,25 @@ function getRequests(req, res) {
   res.json(requests);
 }
 
-module.exports = { getProfiles, likeProfile, passProfile, getRequests };
+function acceptRequest(req, res) {
+  const id = Number(req.params.id);
+  const record = mockStore.acceptSwipeRequest(id);
+  if (!record) {
+    return res.status(404).json({ error: 'Request not found' });
+  }
+  const conversation = record.fromUserId
+    ? mockStore.createConversation('1', record.fromUserId)
+    : null;
+  res.json({ message: 'Request accepted', request: record, conversation });
+}
+
+function rejectRequest(req, res) {
+  const id = Number(req.params.id);
+  const record = mockStore.rejectSwipeRequest(id);
+  if (!record) {
+    return res.status(404).json({ error: 'Request not found' });
+  }
+  res.json({ message: 'Request rejected', request: record });
+}
+
+module.exports = { getProfiles, likeProfile, passProfile, getRequests, acceptRequest, rejectRequest };

--- a/back-end/src/controllers/userController.js
+++ b/back-end/src/controllers/userController.js
@@ -12,11 +12,13 @@ function searchUsersHandler(req, res) {
 
     try {
         const matches = searchUsers({ q, company, school, role, city })
-            .filter((u) => u.id !== currentUserId);
+            .filter((u) => u.id !== currentUserId)
+            .map((u) => enrichUser(u, currentUserId))
+            .filter((u) => !u.connected);
         const total = matches.length;
         const totalPages = Math.ceil(total / limit);
         const offset = (page - 1) * limit;
-        const enriched = matches.slice(offset, offset + limit).map((u) => enrichUser(u, currentUserId));
+        const enriched = matches.slice(offset, offset + limit);
 
         res.json({
             data: enriched,

--- a/back-end/src/routes/swipeRoutes.js
+++ b/back-end/src/routes/swipeRoutes.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const router = express.Router();
-const { getProfiles, likeProfile, passProfile, getRequests } = require('../controllers/swipeController');
+const { getProfiles, likeProfile, passProfile, getRequests, acceptRequest, rejectRequest } = require('../controllers/swipeController');
 
 router.get('/profiles', getProfiles);
 router.post('/like', likeProfile);
 router.post('/pass', passProfile);
 router.get('/requests', getRequests);
+router.post('/requests/:id/accept', acceptRequest);
+router.post('/requests/:id/reject', rejectRequest);
 
 module.exports = router;

--- a/back-end/src/services/connectionsStore.js
+++ b/back-end/src/services/connectionsStore.js
@@ -99,6 +99,20 @@ function deleteConnectionById(id) {
   return record;
 }
 
+// returns 'accepted', 'pending-incoming', 'pending-outgoing', or null
+function getRelationship(userId, otherUserId) {
+  for (const record of connections.values()) {
+    const involves = (record.fromUserId === userId && record.toUserId === otherUserId)
+      || (record.fromUserId === otherUserId && record.toUserId === userId);
+    if (!involves) continue;
+    if (record.status === 'accepted') return 'accepted';
+    if (record.status === 'pending') {
+      return record.toUserId === userId ? 'pending-incoming' : 'pending-outgoing';
+    }
+  }
+  return null;
+}
+
 module.exports = {
   connections,
   addRequest,
@@ -108,5 +122,6 @@ module.exports = {
   acceptRequestById,
   rejectRequestById,
   deleteConnectionById,
-  seedConnections
+  seedConnections,
+  getRelationship,
 };

--- a/back-end/src/services/mockStore.js
+++ b/back-end/src/services/mockStore.js
@@ -164,16 +164,17 @@ const swipeLikes = [];
 const swipePasses = [];
 
 const receivedRequests = [
-  { id: 1, name: 'Priya S.', role: 'Design Intern @ Figma', image: 'https://picsum.photos/seed/priya/100/100' },
-  { id: 2, name: 'Jordan K.', role: 'PM Intern @ Stripe', image: 'https://picsum.photos/seed/jordan/100/100' },
+  { id: 1, fromUserId: '3', fromUser: { name: 'Priya S.', role: 'Design Intern @ Figma', image: 'https://picsum.photos/seed/priya/100/100' } },
+  { id: 2, fromUserId: '4', fromUser: { name: 'Jordan K.', role: 'PM Intern @ Stripe', image: 'https://picsum.photos/seed/jordan/100/100' } },
 ];
+let nextSwipeRequestId = 3;
 
 // ── Messages mock data ──
 const conversations = [
   {
     id: 'c1',
     otherUser: {
-      id: 'u2',
+      id: '2',
       name: 'John Green',
       username: 'jgreen',
       avatar: 'https://picsum.photos/seed/jgreen/100/100',
@@ -186,7 +187,7 @@ const conversations = [
   {
     id: 'c2',
     otherUser: {
-      id: 'u3',
+      id: '200',
       name: 'Elon Musk',
       username: 'emusk',
       avatar: 'https://picsum.photos/seed/emusk/100/100',
@@ -199,7 +200,7 @@ const conversations = [
   {
     id: 'c3',
     otherUser: {
-      id: 'u4',
+      id: '201',
       name: 'Andy Jassy',
       username: 'ajassy',
       avatar: 'https://picsum.photos/seed/ajassy/100/100',
@@ -345,7 +346,13 @@ function getSwipeProfiles() {
 }
 
 function likeProfile(profileId) {
-  swipeLikes.push(profileId);
+  const profile = swipeProfiles.find(p => p.id === profileId);
+  const sentRequest = {
+    id: nextSwipeRequestId++,
+    toUserId: profileId,
+    toUser: profile ? { name: profile.name, role: profile.major, image: profile.image } : null,
+  };
+  swipeLikes.push(sentRequest);
   return { liked: profileId };
 }
 
@@ -356,6 +363,18 @@ function passProfile(profileId) {
 
 function getSwipeRequests() {
   return { received: receivedRequests, sent: swipeLikes };
+}
+
+function acceptSwipeRequest(requestId) {
+  const idx = receivedRequests.findIndex(r => r.id === requestId);
+  if (idx === -1) return null;
+  return receivedRequests.splice(idx, 1)[0];
+}
+
+function rejectSwipeRequest(requestId) {
+  const idx = receivedRequests.findIndex(r => r.id === requestId);
+  if (idx === -1) return null;
+  return receivedRequests.splice(idx, 1)[0];
 }
 
 // ── Messages functions ──
@@ -393,9 +412,7 @@ function sendMessage(conversationId, text) {
 }
 
 function createConversation(currentUserId, otherUserId) {
-  const otherUid = otherUserId.startsWith('u') ? otherUserId : `u${otherUserId}`;
-
-  const existing = conversations.find(c => c.otherUser.id === otherUid);
+  const existing = conversations.find(c => c.otherUser.id === otherUserId);
   if (existing) return existing;
 
   const userInfo = getUserById(otherUserId);
@@ -403,7 +420,7 @@ function createConversation(currentUserId, otherUserId) {
   const newConvo = {
     id: convoId,
     otherUser: {
-      id: otherUid,
+      id: otherUserId,
       name: userInfo.name,
       username: userInfo.name.toLowerCase().replaceAll(' ', ''),
       avatar: userInfo.image,
@@ -435,6 +452,8 @@ module.exports = {
   likeProfile,
   passProfile,
   getSwipeRequests,
+  acceptSwipeRequest,
+  rejectSwipeRequest,
   getConversations,
   getMessages,
   sendMessage,

--- a/back-end/src/services/mockStore.js
+++ b/back-end/src/services/mockStore.js
@@ -94,7 +94,7 @@ const userEvents = {
 // ── Swipe mock data ──
 const swipeProfiles = [
   {
-    id: 1,
+    id: 101,
     name: 'Sarah',
     age: 21,
     major: 'Data Science @ UC Berkeley',
@@ -107,7 +107,7 @@ const swipeProfiles = [
     drinks: 'Socially',
   },
   {
-    id: 2,
+    id: 102,
     name: 'Jessica',
     age: 22,
     major: 'Computer Science @ Stanford',
@@ -120,7 +120,7 @@ const swipeProfiles = [
     drinks: 'Yes',
   },
   {
-    id: 3,
+    id: 103,
     name: 'Alex',
     age: 23,
     major: 'Electrical Engineering @ MIT',
@@ -133,7 +133,7 @@ const swipeProfiles = [
     drinks: 'No',
   },
   {
-    id: 4,
+    id: 104,
     name: 'Elena',
     age: 20,
     major: 'UX/UI Design @ Cal Poly',
@@ -146,7 +146,7 @@ const swipeProfiles = [
     drinks: 'Socially',
   },
   {
-    id: 5,
+    id: 105,
     name: 'Morgan',
     age: 22,
     major: 'Computer Science @ UCSC',

--- a/back-end/src/services/usersStore.js
+++ b/back-end/src/services/usersStore.js
@@ -70,11 +70,15 @@ function getMutualCount(userId, targetId) {
 }
 
 function enrichUser(user, currentUserId) {
+  const { getRelationship } = require('./connectionsStore');
   const { connections, ...publicUser } = user;
+  const relationship = currentUserId ? getRelationship(currentUserId, user.id) : null;
   return {
     ...publicUser,
     degree: currentUserId ? getConnectionDegree(currentUserId, user.id) : null,
     mutualCount: currentUserId ? getMutualCount(currentUserId, user.id) : 0,
+    connected: relationship === 'accepted',
+    connectionStatus: relationship,
   };
 }
 

--- a/back-end/test/messagesRoutes.test.js
+++ b/back-end/test/messagesRoutes.test.js
@@ -54,7 +54,7 @@ describe('Messages Routes', () => {
     expect(res.status).to.equal(201);
     expect(res.body).to.have.property('id');
     expect(res.body.otherUser).to.have.property('name', 'Alex');
-    expect(res.body.otherUser).to.have.property('id', 'u103');
+    expect(res.body.otherUser).to.have.property('id', '103');
   });
 
   it('POST /api/messages should return 400 if userId is missing', async () => {

--- a/back-end/test/swipeRoutes.test.js
+++ b/back-end/test/swipeRoutes.test.js
@@ -16,17 +16,17 @@ describe('Swipe Routes', () => {
   it('POST /api/swipe/like should record a like', async () => {
     const res = await request(app)
       .post('/api/swipe/like')
-      .send({ profileId: 1 });
+      .send({ profileId: 101 });
     expect(res.status).to.equal(200);
-    expect(res.body).to.have.property('liked', 1);
+    expect(res.body).to.have.property('liked', 101);
   });
 
   it('POST /api/swipe/pass should record a pass', async () => {
     const res = await request(app)
       .post('/api/swipe/pass')
-      .send({ profileId: 2 });
+      .send({ profileId: 102 });
     expect(res.status).to.equal(200);
-    expect(res.body).to.have.property('passed', 2);
+    expect(res.body).to.have.property('passed', 102);
   });
 
   it('POST /api/swipe/like should return 400 without profileId', async () => {

--- a/back-end/test/swipeRoutes.test.js
+++ b/back-end/test/swipeRoutes.test.js
@@ -44,4 +44,30 @@ describe('Swipe Routes', () => {
     expect(res.body).to.have.property('sent');
     expect(res.body.received).to.be.an('array');
   });
+
+  it('GET /api/swipe/requests received items should have fromUser', async () => {
+    const res = await request(app).get('/api/swipe/requests');
+    const received = res.body.received;
+    if (received.length > 0) {
+      expect(received[0]).to.have.property('fromUser');
+      expect(received[0].fromUser).to.have.property('name');
+    }
+  });
+
+  it('POST /api/swipe/requests/:id/accept should accept a request', async () => {
+    const res = await request(app).post('/api/swipe/requests/1/accept');
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('request');
+  });
+
+  it('POST /api/swipe/requests/:id/reject should reject a request', async () => {
+    const res = await request(app).post('/api/swipe/requests/2/reject');
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('request');
+  });
+
+  it('POST /api/swipe/requests/:id/accept should return 404 for unknown id', async () => {
+    const res = await request(app).post('/api/swipe/requests/9999/accept');
+    expect(res.status).to.equal(404);
+  });
 });

--- a/front-end/src/pages/MessagesPage.jsx
+++ b/front-end/src/pages/MessagesPage.jsx
@@ -1,15 +1,17 @@
 import { useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import ConversationList from "../components/ConversationList";
 
 export default function MessagesPage() {
   const [conversations, setConversations] = useState([]);
+  const location = useLocation();
 
   useEffect(() => {
     fetch('/api/messages')
       .then(res => res.json())
       .then(data => setConversations(data))
       .catch(err => console.error('Failed to fetch conversations:', err));
-  }, []);
+  }, [location.key]);
 
   return (
     <div className="flex justify-center">

--- a/front-end/src/pages/SwipePage.jsx
+++ b/front-end/src/pages/SwipePage.jsx
@@ -1,13 +1,13 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useContext } from 'react'
+import { ConnectionsContext } from '../context/ConnectionsContext'
 import './SwipePage.css'
 
 function SwipePage() {
+  const { pending, sent, sendRequest, acceptRequest, rejectRequest } = useContext(ConnectionsContext)
   const [profiles, setProfiles] = useState([])
   const [currentIndex, setCurrentIndex] = useState(0)
   const [notification, setNotification] = useState(null)
   const [swipeDirection, setSwipeDirection] = useState(null)
-  const [sentRequests, setSentRequests] = useState([])
-  const [receivedRequests, setReceivedRequests] = useState([])
   const [showRequests, setShowRequests] = useState(false)
   const [requestsTab, setRequestsTab] = useState('received')
 
@@ -16,14 +16,6 @@ function SwipePage() {
       .then(res => res.json())
       .then(data => setProfiles(data))
       .catch(err => console.error('Failed to fetch profiles:', err))
-
-    fetch('/api/swipe/requests')
-      .then(res => res.json())
-      .then(data => {
-        setReceivedRequests(data.received || [])
-        setSentRequests(data.sent || [])
-      })
-      .catch(err => console.error('Failed to fetch requests:', err))
   }, [])
 
   const profile = profiles[currentIndex]
@@ -51,11 +43,8 @@ function SwipePage() {
     setSwipeDirection('right')
     setNotification({ type: 'success', text: `✓ Friend request sent to ${profile.name}!` })
 
-    fetch('/api/swipe/like', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ profileId: profile.id }),
-    }).catch(err => console.error('Failed to like:', err))
+    sendRequest(String(profile.id))
+      .catch(err => console.error('Failed to send request:', err))
 
     setTimeout(() => {
       if (currentIndex < profiles.length - 1) {
@@ -68,26 +57,14 @@ function SwipePage() {
     }, 1600)
   }
 
-  const handleAcceptRequest = (id) => {
-    fetch(`/api/swipe/requests/${id}/accept`, { method: 'POST' })
-      .then(() => setReceivedRequests(prev => prev.filter(r => r.id !== id)))
-      .catch(err => console.error('Failed to accept request:', err))
-  }
-
-  const handleRejectRequest = (id) => {
-    fetch(`/api/swipe/requests/${id}/reject`, { method: 'POST' })
-      .then(() => setReceivedRequests(prev => prev.filter(r => r.id !== id)))
-      .catch(err => console.error('Failed to reject request:', err))
-  }
-
   return (
     <div className="swipe-page">
       <div className="swipe-top-bar">
         <button className="swipe-heart-btn" onClick={() => setShowRequests(true)}>
           ❤️
-          {(sentRequests.length + receivedRequests.length) > 0 && (
+          {(sent.length + pending.length) > 0 && (
             <span className="swipe-heart-badge">
-              {sentRequests.length + receivedRequests.length}
+              {sent.length + pending.length}
             </span>
           )}
         </button>
@@ -171,7 +148,7 @@ function SwipePage() {
                 }`}
                 onClick={() => setRequestsTab('received')}
               >
-                Received ({receivedRequests.length})
+                Received ({pending.length})
               </button>
               <button
                 className={`swipe-requests-tab ${
@@ -179,27 +156,27 @@ function SwipePage() {
                 }`}
                 onClick={() => setRequestsTab('sent')}
               >
-                Sent ({sentRequests.length})
+                Sent ({sent.length})
               </button>
             </div>
 
             <div className="swipe-requests-list">
               {requestsTab === 'received' &&
-                (receivedRequests.length > 0 ? (
-                  receivedRequests.map((req) => (
+                (pending.length > 0 ? (
+                  pending.map((req) => (
                     <div key={req.id} className="swipe-request-item">
                       <img
-                        src={req.fromUser.image}
-                        alt={req.fromUser.name}
+                        src={req.fromUser?.image || `https://picsum.photos/seed/${req.fromUserId}/100/100`}
+                        alt={req.fromUser?.name || 'User'}
                         className="swipe-request-image"
                       />
                       <div className="swipe-request-info">
-                        <h3>{req.fromUser.name}</h3>
-                        <p>{req.fromUser.role}</p>
+                        <h3>{req.fromUser?.name || `User ${req.fromUserId}`}</h3>
+                        <p>{req.fromUser?.role || ''}</p>
                       </div>
                       <div className="swipe-request-actions">
-                        <button className="swipe-request-accept" onClick={() => handleAcceptRequest(req.id)}>✓</button>
-                        <button className="swipe-request-reject" onClick={() => handleRejectRequest(req.id)}>✕</button>
+                        <button className="swipe-request-accept" onClick={() => acceptRequest(req.id)}>✓</button>
+                        <button className="swipe-request-reject" onClick={() => rejectRequest(req.id)}>✕</button>
                       </div>
                     </div>
                   ))
@@ -208,11 +185,11 @@ function SwipePage() {
                 ))}
 
               {requestsTab === 'sent' &&
-                (sentRequests.length > 0 ? (
-                  sentRequests.map((req) => (
+                (sent.length > 0 ? (
+                  sent.map((req) => (
                     <div key={req.id} className="swipe-sent-request-item">
                       <div className="swipe-sent-request-info">
-                        <h3>{req.toUser ? req.toUser.name : `User ${req.toUserId}`}</h3>
+                        <h3>{req.toUser?.name || `User ${req.toUserId}`}</h3>
                         <p>Request sent</p>
                       </div>
                       <span className="swipe-sent-request-badge">⏳</span>

--- a/front-end/src/pages/searchPage/searchPage.jsx
+++ b/front-end/src/pages/searchPage/searchPage.jsx
@@ -19,8 +19,15 @@ function Degreebadge({ degree }) {
   return <span className={`sp-degree sp-degree--${d}`}>{labels[degree]}</span>
 }
 
-function PersonCard({ person, onConnect, onCancel }) {
-  const [status, setStatus] = useState(person.connected ? 'connected' : 'idle')
+function getInitialStatus(person) {
+  if (person.connected) return 'connected'
+  if (person.connectionStatus === 'pending-outgoing') return 'pending'
+  if (person.connectionStatus === 'pending-incoming') return 'incoming'
+  return 'idle'
+}
+
+function PersonCard({ person, onConnect, onCancel, onAccept }) {
+  const [status, setStatus] = useState(() => getInitialStatus(person))
   const [requestId, setRequestId] = useState(null)
 
   const handleConnect = () => {
@@ -32,6 +39,18 @@ function PersonCard({ person, onConnect, onCancel }) {
     onCancel(requestId)
     setStatus('idle')
     setRequestId(null)
+  }
+
+  const handleAccept = () => {
+    onAccept(person.id)
+    setStatus('connected')
+  }
+
+  const label = {
+    connected: 'Connected',
+    pending: 'Pending ✕',
+    incoming: 'Accept',
+    idle: '+ Connect',
   }
 
   return (
@@ -54,17 +73,21 @@ function PersonCard({ person, onConnect, onCancel }) {
       </div>
       <button
         className={`sp-connect-btn sp-connect-btn--${status}`}
-        onClick={status === 'pending' ? handleCancel : handleConnect}
+        onClick={
+          status === 'pending' ? handleCancel
+          : status === 'incoming' ? handleAccept
+          : handleConnect
+        }
         disabled={status === 'connected'}
       >
-        {status === 'connected' ? 'Connected' : status === 'pending' ? 'Pending ✕' : '+ Connect'}
+        {label[status]}
       </button>
     </div>
   )
 }
 
 export default function SearchPage() {
-  const { sendRequest, cancelRequest } = useContext(ConnectionsContext)
+  const { sendRequest, cancelRequest, pending, accepted, acceptRequest } = useContext(ConnectionsContext)
   const [people, setPeople] = useState([])
   const [loading, setLoading] = useState(false)
   const [swipeMode, setSwipeMode] = useState(false)
@@ -106,7 +129,7 @@ export default function SearchPage() {
       .then(json => setPeople(json.data || []))
       .catch(err => console.error('Search fetch failed:', err))
       .finally(() => setLoading(false))
-  }, [query, applied])
+  }, [query, applied, pending, accepted])
 
   const toggleMulti = (key, value) => {
     setFilters(prev => {
@@ -143,6 +166,11 @@ export default function SearchPage() {
 
   const handleConnect = (id) => sendRequest(String(id))
   const handleCancel = (requestId) => cancelRequest(requestId)
+  const handleAcceptFromSearch = (id) => {
+    // find the pending request for this user and accept it
+    const req = pending.find(r => r.fromUserId === String(id))
+    if (req) acceptRequest(req.id)
+  }
 
   if (swipeMode) {
     return (
@@ -203,7 +231,7 @@ export default function SearchPage() {
           : results.length === 0
             ? <p className="sp-empty">No results. Try adjusting your filters.</p>
             : results.map(p => (
-                <PersonCard key={p.id} person={p} onConnect={handleConnect} onCancel={handleCancel} />
+                <PersonCard key={p.id} person={p} onConnect={handleConnect} onCancel={handleCancel} onAccept={handleAcceptFromSearch} />
               ))
         }
       </div>


### PR DESCRIPTION
fixed swipe requests, added accept/reject endpoints for convos, accept now creates a convo, removed ‘u’ prefix from users for better consistency, aligned the swipe profile IDs so the mock data was consistent w functionality, search filters out already connected ppl, swipepage uses connection context insted of separate thing from search, refettches when connection state changes for updates
<img width="393" height="511" alt="Screenshot 2026-04-13 at 10 19 59 PM" src="https://github.com/user-attachments/assets/dcf357a4-c9dc-4b50-ab80-fe4a91899abe" />
<img width="454" height="306" alt="Screenshot 2026-04-13 at 10 20 08 PM" src="https://github.com/user-attachments/assets/d08ada4f-47c1-4b47-a3c5-4d75f3c3bb35" />
<img width="390" height="301" alt="Screenshot 2026-04-13 at 10 20 23 PM" src="https://github.com/user-attachments/assets/33b11dad-0b9e-4dce-9fca-a9709029f61c" />
