### PR TITLE
unify swipe and search into single data source, remove dead swipe end…

### DIFF
--- a/back-end/src/controllers/swipeController.js
+++ b/back-end/src/controllers/swipeController.js
@@ -1,52 +1,9 @@
-const mockStore = require('../services/mockStore');
+const { getSwipeProfiles } = require('../services/usersStore');
 
 function getProfiles(req, res) {
-  const profiles = mockStore.getSwipeProfiles();
+  const currentUserId = req.headers['x-current-user-id'] || '1';
+  const profiles = getSwipeProfiles(currentUserId);
   res.json(profiles);
 }
 
-function likeProfile(req, res) {
-  const { profileId } = req.body;
-  if (!profileId) {
-    return res.status(400).json({ error: 'profileId is required' });
-  }
-  const result = mockStore.likeProfile(profileId);
-  res.json(result);
-}
-
-function passProfile(req, res) {
-  const { profileId } = req.body;
-  if (!profileId) {
-    return res.status(400).json({ error: 'profileId is required' });
-  }
-  const result = mockStore.passProfile(profileId);
-  res.json(result);
-}
-
-function getRequests(req, res) {
-  const requests = mockStore.getSwipeRequests();
-  res.json(requests);
-}
-
-function acceptRequest(req, res) {
-  const id = Number(req.params.id);
-  const record = mockStore.acceptSwipeRequest(id);
-  if (!record) {
-    return res.status(404).json({ error: 'Request not found' });
-  }
-  const conversation = record.fromUserId
-    ? mockStore.createConversation('1', record.fromUserId)
-    : null;
-  res.json({ message: 'Request accepted', request: record, conversation });
-}
-
-function rejectRequest(req, res) {
-  const id = Number(req.params.id);
-  const record = mockStore.rejectSwipeRequest(id);
-  if (!record) {
-    return res.status(404).json({ error: 'Request not found' });
-  }
-  res.json({ message: 'Request rejected', request: record });
-}
-
-module.exports = { getProfiles, likeProfile, passProfile, getRequests, acceptRequest, rejectRequest };
+module.exports = { getProfiles };

--- a/back-end/src/routes/swipeRoutes.js
+++ b/back-end/src/routes/swipeRoutes.js
@@ -1,12 +1,7 @@
 const express = require('express');
 const router = express.Router();
-const { getProfiles, likeProfile, passProfile, getRequests, acceptRequest, rejectRequest } = require('../controllers/swipeController');
+const { getProfiles } = require('../controllers/swipeController');
 
 router.get('/profiles', getProfiles);
-router.post('/like', likeProfile);
-router.post('/pass', passProfile);
-router.get('/requests', getRequests);
-router.post('/requests/:id/accept', acceptRequest);
-router.post('/requests/:id/reject', rejectRequest);
 
 module.exports = router;

--- a/back-end/src/services/mockStore.js
+++ b/back-end/src/services/mockStore.js
@@ -91,84 +91,6 @@ const userEvents = {
   ],
 };
 
-// ── Swipe mock data ──
-const swipeProfiles = [
-  {
-    id: 101,
-    name: 'Sarah',
-    age: 21,
-    major: 'Data Science @ UC Berkeley',
-    internshipFull: 'Data Science Intern @ Google',
-    locationFull: 'San Francisco, CA | May – Aug 2026',
-    about: 'I love data, coffee, and exploring new neighborhoods. Excited to meet other interns this summer!',
-    pronouns: 'she/her',
-    image: 'https://picsum.photos/seed/profile1/400/500',
-    interests: ['Music', 'Food', 'Reading', 'Art'],
-    drinks: 'Socially',
-  },
-  {
-    id: 102,
-    name: 'Jessica',
-    age: 22,
-    major: 'Computer Science @ Stanford',
-    internshipFull: 'Software Engineer Intern @ Meta',
-    locationFull: 'San Francisco, CA | May – Aug 2026',
-    about: 'Full-stack developer, startup enthusiast, love hiking and trying new restaurants around the Bay.',
-    pronouns: 'she/her',
-    image: 'https://picsum.photos/seed/profile2/400/500',
-    interests: ['Sports', 'Party', 'Creation', 'Cafes'],
-    drinks: 'Yes',
-  },
-  {
-    id: 103,
-    name: 'Alex',
-    age: 23,
-    major: 'Electrical Engineering @ MIT',
-    internshipFull: 'Product Manager Intern @ Apple',
-    locationFull: 'San Francisco, CA | May – Aug 2026',
-    about: "I love building products that matter. When I'm not working, you can find me at concerts or reading sci-fi.",
-    pronouns: 'they/them',
-    image: 'https://picsum.photos/seed/profile3/400/500',
-    interests: ['Music', 'Creation', 'Reading', 'Swimming'],
-    drinks: 'No',
-  },
-  {
-    id: 104,
-    name: 'Elena',
-    age: 20,
-    major: 'UX/UI Design @ Cal Poly',
-    internshipFull: 'UX Designer Intern @ Adobe',
-    locationFull: 'San Francisco, CA | May – Aug 2026',
-    about: 'Design lover and coffee enthusiast. I enjoy sketching, photography, and meeting creative people!',
-    pronouns: 'she/her',
-    image: 'https://picsum.photos/seed/profile4/400/500',
-    interests: ['Food', 'Creation', 'Drinks', 'Photography'],
-    drinks: 'Socially',
-  },
-  {
-    id: 105,
-    name: 'Morgan',
-    age: 22,
-    major: 'Computer Science @ UCSC',
-    internshipFull: 'Backend Engineer Intern @ Stripe',
-    locationFull: 'San Francisco, CA | May – Aug 2026',
-    about: 'Backend optimization nerd, weekend athlete, and always down for a good game night.',
-    pronouns: 'he/him',
-    image: 'https://picsum.photos/seed/profile5/400/500',
-    interests: ['Sports', 'Reading', 'Music', 'Gaming'],
-    drinks: 'Socially',
-  },
-];
-
-const swipeLikes = [];
-const swipePasses = [];
-
-const receivedRequests = [
-  { id: 1, fromUserId: '3', fromUser: { name: 'Priya S.', role: 'Design Intern @ Figma', image: 'https://picsum.photos/seed/priya/100/100' } },
-  { id: 2, fromUserId: '4', fromUser: { name: 'Jordan K.', role: 'PM Intern @ Stripe', image: 'https://picsum.photos/seed/jordan/100/100' } },
-];
-let nextSwipeRequestId = 3;
-
 // ── Messages mock data ──
 const conversations = [
   {
@@ -340,43 +262,6 @@ function createEvent({ title, description, location, date, time, privacy }) {
   return newEvent;
 }
 
-// ── Swipe functions ──
-function getSwipeProfiles() {
-  return swipeProfiles;
-}
-
-function likeProfile(profileId) {
-  const profile = swipeProfiles.find(p => p.id === profileId);
-  const sentRequest = {
-    id: nextSwipeRequestId++,
-    toUserId: profileId,
-    toUser: profile ? { name: profile.name, role: profile.major, image: profile.image } : null,
-  };
-  swipeLikes.push(sentRequest);
-  return { liked: profileId };
-}
-
-function passProfile(profileId) {
-  swipePasses.push(profileId);
-  return { passed: profileId };
-}
-
-function getSwipeRequests() {
-  return { received: receivedRequests, sent: swipeLikes };
-}
-
-function acceptSwipeRequest(requestId) {
-  const idx = receivedRequests.findIndex(r => r.id === requestId);
-  if (idx === -1) return null;
-  return receivedRequests.splice(idx, 1)[0];
-}
-
-function rejectSwipeRequest(requestId) {
-  const idx = receivedRequests.findIndex(r => r.id === requestId);
-  if (idx === -1) return null;
-  return receivedRequests.splice(idx, 1)[0];
-}
-
 // ── Messages functions ──
 function getConversations() {
   return conversations;
@@ -448,12 +333,6 @@ module.exports = {
   getEventById,
   getUserEvents,
   createEvent,
-  getSwipeProfiles,
-  likeProfile,
-  passProfile,
-  getSwipeRequests,
-  acceptSwipeRequest,
-  rejectSwipeRequest,
   getConversations,
   getMessages,
   sendMessage,

--- a/back-end/src/services/usersStore.js
+++ b/back-end/src/services/usersStore.js
@@ -1,16 +1,18 @@
 //const { use } = require("react");
+//Both search and swipe read from here now
 
-// mock user profiles - just enough data to display in the connections UI
+// mock user profiles for connections UI
 const users = new Map([
+  // these are not swipable cuz they're already connected (and lisa is us) so i didn't add all the new info for them bc time consuming, but in production we would have all the fields for all users yeah
   ['1', { id: '1', name: 'Lisa', role: 'SWE Intern', school: 'Stanford University', company: 'Airbnb', city: 'San Francisco, CA', image: 'https://picsum.photos/seed/user1/100/100', connections: ['2', '3'] }],
   ['2', { id: '2', name: 'John Green', role: 'SWE Intern', school: 'University of Waterloo', company: 'Google', city: 'New York, NY', image: 'https://picsum.photos/seed/user2/100/100', connections: ['1', '3', '4', '101'] }],
   ['3', { id: '3', name: 'Priya S.', role: 'Design Intern', school: 'NYU', company: 'Figma', city: 'New York, NY', image: 'https://picsum.photos/seed/user3/100/100', connections: ['1', '2', '104'] }],
   ['4', { id: '4', name: 'Jordan K.', role: 'PM Intern', school: 'MIT', company: 'Stripe', city: 'Boston, MA', image: 'https://picsum.photos/seed/user4/100/100', connections: ['2', '101'] }],
-  ['101', { id: '101', name: 'Sarah', role: 'Data Science Intern', school: 'UIUC', company: 'Google', city: 'Chicago, IL', image: 'https://picsum.photos/seed/profile1/100/100', connections: ['2', '4', '102', '103'] }],
-  ['102', { id: '102', name: 'Jessica', role: 'SWE Intern', school: 'Georgia Tech', company: 'Meta', city: 'New York, NY', image: 'https://picsum.photos/seed/profile2/100/100', connections: ['101', '103'] }],
-  ['103', { id: '103', name: 'Alex', role: 'PM Intern', school: 'Harvard University', company: 'Apple', city: 'Boston, MA', image: 'https://picsum.photos/seed/profile3/100/100', connections: ['101', '102'] }],
-  ['104', { id: '104', name: 'Elena', role: 'UX Design Intern', school: 'RISD', company: 'Adobe', city: 'New York, NY', image: 'https://picsum.photos/seed/profile4/100/100', connections: ['3', '105'] }],
-  ['105', { id: '105', name: 'Morgan', role: 'Backend Intern', school: 'UC Berkeley', company: 'Stripe', city: 'San Francisco, CA', image: 'https://picsum.photos/seed/profile5/100/100', connections: ['104'] }],
+  ['101', { id: '101', name: 'Sarah', role: 'Data Science Intern', school: 'UIUC', company: 'Google', city: 'Chicago, IL', image: 'https://picsum.photos/seed/profile1/100/100', swipeImage: 'https://picsum.photos/seed/profile1/400/500', connections: ['2', '4', '102', '103'], age: 21, major: 'Data Science @ UIUC', internshipFull: 'Data Science Intern @ Google', locationFull: 'Chicago, IL | May – Aug 2026', about: 'I love data, coffee, and exploring new neighborhoods. Excited to meet other interns this summer!', pronouns: 'she/her', interests: ['Music', 'Food', 'Reading', 'Art'], drinks: 'Socially' }],
+  ['102', { id: '102', name: 'Jessica', role: 'SWE Intern', school: 'Georgia Tech', company: 'Meta', city: 'New York, NY', image: 'https://picsum.photos/seed/profile2/100/100', swipeImage: 'https://picsum.photos/seed/profile2/400/500', connections: ['101', '103'], age: 22, major: 'Computer Science @ Georgia Tech', internshipFull: 'Software Engineer Intern @ Meta', locationFull: 'New York, NY | May – Aug 2026', about: 'Full-stack developer, startup enthusiast, love hiking and trying new restaurants around the Bay.', pronouns: 'she/her', interests: ['Sports', 'Party', 'Creation', 'Cafes'], drinks: 'Yes' }],
+  ['103', { id: '103', name: 'Alex', role: 'PM Intern', school: 'Harvard University', company: 'Apple', city: 'Boston, MA', image: 'https://picsum.photos/seed/profile3/100/100', swipeImage: 'https://picsum.photos/seed/profile3/400/500', connections: ['101', '102'], age: 23, major: 'Electrical Engineering @ Harvard', internshipFull: 'Product Manager Intern @ Apple', locationFull: 'Boston, MA | May – Aug 2026', about: "I love building products that matter. When I'm not working, you can find me at concerts or reading sci-fi.", pronouns: 'they/them', interests: ['Music', 'Creation', 'Reading', 'Swimming'], drinks: 'No' }],
+  ['104', { id: '104', name: 'Elena', role: 'UX Design Intern', school: 'RISD', company: 'Adobe', city: 'New York, NY', image: 'https://picsum.photos/seed/profile4/100/100', swipeImage: 'https://picsum.photos/seed/profile4/400/500', connections: ['3', '105'], age: 20, major: 'UX/UI Design @ RISD', internshipFull: 'UX Designer Intern @ Adobe', locationFull: 'New York, NY | May – Aug 2026', about: 'Design lover and coffee enthusiast. I enjoy sketching, photography, and meeting creative people!', pronouns: 'she/her', interests: ['Food', 'Creation', 'Drinks', 'Photography'], drinks: 'Socially' }],
+  ['105', { id: '105', name: 'Morgan', role: 'Backend Intern', school: 'UC Berkeley', company: 'Stripe', city: 'San Francisco, CA', image: 'https://picsum.photos/seed/profile5/100/100', swipeImage: 'https://picsum.photos/seed/profile5/400/500', connections: ['104'], age: 22, major: 'Computer Science @ UC Berkeley', internshipFull: 'Backend Engineer Intern @ Stripe', locationFull: 'San Francisco, CA | May – Aug 2026', about: 'Backend optimization nerd, weekend athlete, and always down for a good game night.', pronouns: 'he/him', interests: ['Sports', 'Reading', 'Music', 'Gaming'], drinks: 'Socially' }],
 ]);
 
 function getAllUsers(){
@@ -82,4 +84,16 @@ function enrichUser(user, currentUserId) {
   };
 }
 
-module.exports = { getUserById, searchUsers, getAllUsers, getConnectionDegree, getMutualCount, enrichUser}
+// returns swipe-ready profiles, filtered by connection status
+function getSwipeProfiles(currentUserId) {
+  const { getRelationship } = require('./connectionsStore');
+  return Array.from(users.values())
+    .filter(u => u.swipeImage)
+    .filter(u => u.id !== currentUserId)
+    .filter(u => {
+      const rel = getRelationship(currentUserId, u.id);
+      return rel !== 'accepted' && rel !== 'pending-outgoing';
+    });
+}
+
+module.exports = { getUserById, searchUsers, getAllUsers, getConnectionDegree, getMutualCount, enrichUser, getSwipeProfiles }

--- a/back-end/test/swipeRoutes.test.js
+++ b/back-end/test/swipeRoutes.test.js
@@ -11,63 +11,26 @@ describe('Swipe Routes', () => {
     expect(res.body.length).to.be.greaterThan(0);
     expect(res.body[0]).to.have.property('name');
     expect(res.body[0]).to.have.property('internshipFull');
+    expect(res.body[0]).to.have.property('age');
+    expect(res.body[0]).to.have.property('swipeImage');
   });
 
-  it('POST /api/swipe/like should record a like', async () => {
+  it('GET /api/swipe/profiles should not include the current user', async () => {
     const res = await request(app)
-      .post('/api/swipe/like')
-      .send({ profileId: 101 });
+      .get('/api/swipe/profiles')
+      .set('x-current-user-id', '101');
     expect(res.status).to.equal(200);
-    expect(res.body).to.have.property('liked', 101);
+    const ids = res.body.map(p => p.id);
+    expect(ids).to.not.include('101');
   });
 
-  it('POST /api/swipe/pass should record a pass', async () => {
+  it('GET /api/swipe/profiles should not include connected users', async () => {
+    // user 1 is connected to user 2 (seeded in connectionsStore)
     const res = await request(app)
-      .post('/api/swipe/pass')
-      .send({ profileId: 102 });
+      .get('/api/swipe/profiles')
+      .set('x-current-user-id', '1');
     expect(res.status).to.equal(200);
-    expect(res.body).to.have.property('passed', 102);
-  });
-
-  it('POST /api/swipe/like should return 400 without profileId', async () => {
-    const res = await request(app)
-      .post('/api/swipe/like')
-      .send({});
-    expect(res.status).to.equal(400);
-    expect(res.body).to.have.property('error');
-  });
-
-  it('GET /api/swipe/requests should return received and sent', async () => {
-    const res = await request(app).get('/api/swipe/requests');
-    expect(res.status).to.equal(200);
-    expect(res.body).to.have.property('received');
-    expect(res.body).to.have.property('sent');
-    expect(res.body.received).to.be.an('array');
-  });
-
-  it('GET /api/swipe/requests received items should have fromUser', async () => {
-    const res = await request(app).get('/api/swipe/requests');
-    const received = res.body.received;
-    if (received.length > 0) {
-      expect(received[0]).to.have.property('fromUser');
-      expect(received[0].fromUser).to.have.property('name');
-    }
-  });
-
-  it('POST /api/swipe/requests/:id/accept should accept a request', async () => {
-    const res = await request(app).post('/api/swipe/requests/1/accept');
-    expect(res.status).to.equal(200);
-    expect(res.body).to.have.property('request');
-  });
-
-  it('POST /api/swipe/requests/:id/reject should reject a request', async () => {
-    const res = await request(app).post('/api/swipe/requests/2/reject');
-    expect(res.status).to.equal(200);
-    expect(res.body).to.have.property('request');
-  });
-
-  it('POST /api/swipe/requests/:id/accept should return 404 for unknown id', async () => {
-    const res = await request(app).post('/api/swipe/requests/9999/accept');
-    expect(res.status).to.equal(404);
+    const ids = res.body.map(p => p.id);
+    expect(ids).to.not.include('2');
   });
 });

--- a/front-end/src/pages/SwipePage.jsx
+++ b/front-end/src/pages/SwipePage.jsx
@@ -80,7 +80,7 @@ function SwipePage() {
         <div className="swipe-card-wrapper">
           <div className={`swipe-card-container ${swipeDirection ? `swipe-${swipeDirection}` : ''}`}>
             <div className="swipe-card">
-              <img className="swipe-image" src={profile.image} alt={profile.name} />
+              <img className="swipe-image" src={profile.swipeImage || profile.image} alt={profile.name} />
             </div>
 
             <div className="swipe-info-section">

--- a/front-end/src/pages/searchPage/searchPage.jsx
+++ b/front-end/src/pages/searchPage/searchPage.jsx
@@ -10,7 +10,6 @@ const ROLES = ['SWE Intern', 'PM Intern', 'Design Intern', 'Data Intern', 'Finan
 const CITIES = ['New York, NY', 'San Francisco, CA', 'Seattle, WA', 'Austin, TX', 'Boston, MA', 'Chicago, IL']
 const RADII = ['5 mi', '10 mi', '25 mi', '50 mi', 'Any']
 
-const API_BASE = 'http://localhost:3001'
 const CURRENT_USER_ID = '1'
 
 function Degreebadge({ degree }) {
@@ -121,8 +120,7 @@ export default function SearchPage() {
 
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true)
-    console.log('Fetching:', `${API_BASE}/api/users/search?${params.toString()}`)
-    fetch(`${API_BASE}/api/users/search?${params}`, {
+    fetch(`/api/users/search?${params}`, {
       headers: { 'x-current-user-id': CURRENT_USER_ID }
     })
       .then(res => res.json())


### PR DESCRIPTION
unify swipe and search into single data source, remove dead swipe endpoints. Connected and pending-outgoing users r filtered out of search results now too. also removed hardcoded localhost:3001 so it's the same as others (uses the proxy)
removed dead swipe endpoints (/like, /pass, /requests, accept, reject) since frontend uses ConnectionsContext. stuff like dedup pending whatnot - etc these r better fixed during database, there are still limitations of hardcoded data so 

