### PR TITLE
migrate events, swipe, and messages to MongoDB

### DIFF
--- a/back-end/.mocharc.cjs
+++ b/back-end/.mocharc.cjs
@@ -1,0 +1,2 @@
+require('dotenv').config();
+module.exports = {};

--- a/back-end/src/controllers/eventsController.js
+++ b/back-end/src/controllers/eventsController.js
@@ -1,30 +1,104 @@
-const mockStore = require('../services/mockStore');
+const mongoose = require('mongoose');
+const Event = require('../models/Event');
 
-function getAllEvents(req, res) {
-  const events = mockStore.getEvents();
-  res.json(events);
+function serializeEvent(event) {
+  return {
+    id: String(event._id),
+    title: event.title,
+    description: event.description,
+    location: event.location,
+    date: event.date,
+    time: event.time,
+    privacy: event.privacy,
+    createdBy: event.createdBy ? String(event.createdBy) : null,
+    attendees: (event.attendees || []).map(String),
+    createdAt: event.createdAt,
+  };
 }
 
-function getEventById(req, res) {
-  const event = mockStore.getEventById(req.params.id);
-  if (!event) {
-    return res.status(404).json({ error: 'Event not found' });
+async function getAllEvents(req, res, next) {
+  try {
+    const events = await Event.find({ privacy: 'public' })
+      .sort({ createdAt: -1 })
+      .lean();
+    return res.status(200).json(events.map(serializeEvent));
+  } catch (err) {
+    return next(err);
   }
-  res.json(event);
 }
 
-function getUserEvents(req, res) {
-  const data = mockStore.getUserEvents();
-  res.json(data);
-}
+async function getEventById(req, res, next) {
+  try {
+    const { id } = req.params;
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(404).json({ error: 'Event not found' });
+    }
 
-function createEvent(req, res) {
-  const { title } = req.body;
-  if (!title) {
-    return res.status(400).json({ error: 'Title is required' });
+    const event = await Event.findById(id).lean();
+    if (!event) {
+      return res.status(404).json({ error: 'Event not found' });
+    }
+
+    return res.status(200).json(serializeEvent(event));
+  } catch (err) {
+    return next(err);
   }
-  const event = mockStore.createEvent(req.body);
-  res.status(201).json(event);
+}
+
+async function getUserEvents(req, res, next) {
+  try {
+    const userId = req.auth.userId;
+
+    const [hosting, attending, privateEvents, suggested] = await Promise.all([
+      Event.find({ createdBy: userId }).sort({ createdAt: -1 }).lean(),
+      Event.find({
+        attendees: userId,
+        createdBy: { $ne: userId },
+        privacy: 'public',
+      }).sort({ createdAt: -1 }).lean(),
+      Event.find({
+        privacy: 'private',
+        attendees: userId,
+        createdBy: { $ne: userId },
+      }).sort({ createdAt: -1 }).lean(),
+      Event.find({
+        privacy: 'public',
+        createdBy: { $ne: userId },
+        attendees: { $ne: userId },
+      }).sort({ createdAt: -1 }).limit(10).lean(),
+    ]);
+
+    return res.status(200).json({
+      hosting: hosting.map(serializeEvent),
+      attending: attending.map(serializeEvent),
+      private: privateEvents.map(serializeEvent),
+      suggested: suggested.map(serializeEvent),
+    });
+  } catch (err) {
+    return next(err);
+  }
+}
+
+async function createEvent(req, res, next) {
+  try {
+    const userId = req.auth.userId;
+    const { title, description, location, date, time, privacy } = req.body;
+
+    const event = await Event.create({
+      title,
+      description: description || '',
+      location: location || '',
+      date: date || '',
+      time: time || '',
+      privacy: privacy || 'public',
+      createdBy: userId,
+      attendees: [userId],
+    });
+
+    return res.status(201).json(serializeEvent(event));
+  } catch (err) {
+    return next(err);
+  }
 }
 
 module.exports = { getAllEvents, getEventById, getUserEvents, createEvent };

--- a/back-end/src/controllers/messagesController.js
+++ b/back-end/src/controllers/messagesController.js
@@ -1,37 +1,232 @@
-const mockStore = require('../services/mockStore');
+const mongoose = require('mongoose');
+const Conversation = require('../models/Conversation');
+const User = require('../models/User');
+const Profile = require('../models/Profile');
 
-function getConversations(req, res) {
-  const conversations = mockStore.getConversations();
-  res.json(conversations);
-}
+async function buildOtherUserSummary(otherUserId) {
+  const [user, profile] = await Promise.all([
+    User.findById(otherUserId).lean(),
+    Profile.findOne({ userId: otherUserId }).lean(),
+  ]);
 
-function getMessages(req, res) {
-  const data = mockStore.getMessages(req.params.conversationId);
-  if (!data) {
-    return res.status(404).json({ error: 'Conversation not found' });
+  if (!user) {
+    return {
+      id: String(otherUserId),
+      name: 'Unknown User',
+      username: '',
+      avatar: `https://picsum.photos/seed/${otherUserId}/100/100`,
+      subtitle: '',
+    };
   }
-  res.json(data);
-}
 
-function sendMessage(req, res) {
-  const { text } = req.body;
-  if (!text) {
-    return res.status(400).json({ error: 'text is required' });
+  const displayName =
+    (profile && profile.name) || (user.email ? user.email.split('@')[0] : 'User');
+  const subtitleParts = [];
+  if (profile) {
+    if (profile.jobTitle || profile.company) {
+      subtitleParts.push(
+        [profile.jobTitle, profile.company].filter(Boolean).join(' @ ')
+      );
+    } else if (profile.school) {
+      subtitleParts.push(profile.school);
+    }
   }
-  const message = mockStore.sendMessage(req.params.conversationId, text);
-  res.status(201).json(message);
+
+  return {
+    id: String(user._id),
+    name: displayName,
+    username: user.email ? user.email.split('@')[0] : '',
+    avatar: (profile && (profile.image || profile.swipeImage)) ||
+      `https://picsum.photos/seed/${user._id}/100/100`,
+    subtitle: subtitleParts.join(' · '),
+  };
 }
 
-function createConversation(req, res) {
-  const { userId, otherUserId } = req.body;
-  if (!userId || !otherUserId) {
-    return res.status(400).json({
-      error: 'Missing required fields',
-      required: ['userId', 'otherUserId'],
+function formatTimestamp(date) {
+  if (!date) return '';
+  const now = Date.now();
+  const diffMs = now - new Date(date).getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'now';
+  if (diffMin < 60) return `${diffMin}m`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay}d`;
+}
+
+async function getConversations(req, res, next) {
+  try {
+    const userId = req.auth.userId;
+    const myObjectId = new mongoose.Types.ObjectId(userId);
+
+    const convos = await Conversation.find({ participants: myObjectId })
+      .sort({ lastMessageAt: -1, updatedAt: -1 })
+      .lean();
+
+    const results = await Promise.all(
+      convos.map(async (c) => {
+        const otherUserId = (c.participants || []).find(
+          (p) => String(p) !== String(userId)
+        );
+        const otherUser = await buildOtherUserSummary(otherUserId);
+        return {
+          id: String(c._id),
+          otherUser,
+          lastMessage: c.lastMessage || '',
+          timestamp: formatTimestamp(c.lastMessageAt || c.updatedAt),
+          unreadCount: 0,
+        };
+      })
+    );
+
+    return res.status(200).json(results);
+  } catch (err) {
+    return next(err);
+  }
+}
+
+async function getMessages(req, res, next) {
+  try {
+    const userId = req.auth.userId;
+    const { conversationId } = req.params;
+
+    if (!mongoose.isValidObjectId(conversationId)) {
+      return res.status(404).json({ error: 'Conversation not found' });
+    }
+
+    const convo = await Conversation.findById(conversationId).lean();
+    if (!convo) {
+      return res.status(404).json({ error: 'Conversation not found' });
+    }
+
+    const isParticipant = (convo.participants || []).some(
+      (p) => String(p) === String(userId)
+    );
+    if (!isParticipant) {
+      return res.status(403).json({ error: 'Not a participant in this conversation' });
+    }
+
+    const otherUserId = (convo.participants || []).find(
+      (p) => String(p) !== String(userId)
+    );
+    const otherUser = await buildOtherUserSummary(otherUserId);
+
+    const messages = (convo.messages || []).map((m) => ({
+      id: String(m._id),
+      sender: String(m.sender) === String(userId) ? 'me' : 'them',
+      text: m.text,
+      createdAt: m.createdAt,
+    }));
+
+    return res.status(200).json({
+      conversation: {
+        id: String(convo._id),
+        otherUser,
+        lastMessage: convo.lastMessage || '',
+        timestamp: formatTimestamp(convo.lastMessageAt || convo.updatedAt),
+        unreadCount: 0,
+      },
+      messages,
     });
+  } catch (err) {
+    return next(err);
   }
-  const conversation = mockStore.createConversation(userId, otherUserId);
-  res.status(201).json(conversation);
 }
 
-module.exports = { getConversations, getMessages, sendMessage, createConversation };
+async function sendMessage(req, res, next) {
+  try {
+    const userId = req.auth.userId;
+    const { conversationId } = req.params;
+    const { text } = req.body;
+
+    if (!mongoose.isValidObjectId(conversationId)) {
+      return res.status(404).json({ error: 'Conversation not found' });
+    }
+
+    const convo = await Conversation.findById(conversationId);
+    if (!convo) {
+      return res.status(404).json({ error: 'Conversation not found' });
+    }
+
+    const isParticipant = (convo.participants || []).some(
+      (p) => String(p) === String(userId)
+    );
+    if (!isParticipant) {
+      return res.status(403).json({ error: 'Not a participant in this conversation' });
+    }
+
+    const message = {
+      sender: userId,
+      text,
+    };
+    convo.messages.push(message);
+    convo.lastMessage = text;
+    convo.lastMessageAt = new Date();
+    await convo.save();
+
+    const saved = convo.messages[convo.messages.length - 1];
+
+    return res.status(201).json({
+      id: String(saved._id),
+      sender: 'me',
+      text: saved.text,
+      createdAt: saved.createdAt,
+    });
+  } catch (err) {
+    return next(err);
+  }
+}
+
+async function createConversation(req, res, next) {
+  try {
+    const userId = req.auth.userId;
+    const { otherUserId } = req.body;
+
+    if (String(otherUserId) === String(userId)) {
+      return res.status(400).json({ error: 'Cannot create a conversation with yourself' });
+    }
+
+    if (!mongoose.isValidObjectId(otherUserId)) {
+      return res.status(400).json({ error: 'Invalid otherUserId' });
+    }
+
+    const otherUser = await User.findById(otherUserId);
+    if (!otherUser) {
+      return res.status(404).json({ error: 'Other user not found' });
+    }
+
+    const myObjectId = new mongoose.Types.ObjectId(userId);
+    const otherObjectId = new mongoose.Types.ObjectId(otherUserId);
+
+    let convo = await Conversation.findOne({
+      participants: { $all: [myObjectId, otherObjectId], $size: 2 },
+    });
+
+    if (!convo) {
+      convo = await Conversation.create({
+        participants: [myObjectId, otherObjectId],
+        messages: [],
+      });
+    }
+
+    const otherUserSummary = await buildOtherUserSummary(otherObjectId);
+
+    return res.status(201).json({
+      id: String(convo._id),
+      otherUser: otherUserSummary,
+      lastMessage: convo.lastMessage || '',
+      timestamp: formatTimestamp(convo.lastMessageAt || convo.updatedAt || convo.createdAt),
+      unreadCount: 0,
+    });
+  } catch (err) {
+    return next(err);
+  }
+}
+
+module.exports = {
+  getConversations,
+  getMessages,
+  sendMessage,
+  createConversation,
+};

--- a/back-end/src/controllers/swipeController.js
+++ b/back-end/src/controllers/swipeController.js
@@ -1,9 +1,67 @@
+const Swipe = require('../models/Swipe');
 const { getSwipeProfiles } = require('../services/usersStore');
 
-function getProfiles(req, res) {
-  const currentUserId = req.headers['x-current-user-id'] || '1';
-  const profiles = getSwipeProfiles(currentUserId);
-  res.json(profiles);
+async function getProfiles(req, res, next) {
+  try {
+    const userId = req.auth.userId;
+
+    const swipes = await Swipe.find({ userId }).lean();
+    const swipedIds = new Set(swipes.map((s) => s.targetProfileId));
+
+    const allProfiles = getSwipeProfiles(userId);
+    const unseen = allProfiles.filter((p) => !swipedIds.has(String(p.id)));
+
+    return res.status(200).json(unseen);
+  } catch (err) {
+    return next(err);
+  }
 }
 
-module.exports = { getProfiles };
+async function recordSwipe(req, res, next, action) {
+  try {
+    const userId = req.auth.userId;
+    const { profileId } = req.body;
+
+    const swipe = await Swipe.findOneAndUpdate(
+      { userId, targetProfileId: String(profileId) },
+      { userId, targetProfileId: String(profileId), action },
+      { new: true, upsert: true, runValidators: true }
+    );
+
+    return res.status(200).json({
+      id: String(swipe._id),
+      userId: String(swipe.userId),
+      targetProfileId: swipe.targetProfileId,
+      action: swipe.action,
+    });
+  } catch (err) {
+    return next(err);
+  }
+}
+
+function likeProfile(req, res, next) {
+  return recordSwipe(req, res, next, 'like');
+}
+
+function passProfile(req, res, next) {
+  return recordSwipe(req, res, next, 'pass');
+}
+
+async function getHistory(req, res, next) {
+  try {
+    const userId = req.auth.userId;
+    const swipes = await Swipe.find({ userId }).sort({ createdAt: -1 }).lean();
+    return res.status(200).json(
+      swipes.map((s) => ({
+        id: String(s._id),
+        targetProfileId: s.targetProfileId,
+        action: s.action,
+        createdAt: s.createdAt,
+      }))
+    );
+  } catch (err) {
+    return next(err);
+  }
+}
+
+module.exports = { getProfiles, likeProfile, passProfile, getHistory };

--- a/back-end/src/models/Swipe.js
+++ b/back-end/src/models/Swipe.js
@@ -1,0 +1,26 @@
+const mongoose = require('mongoose');
+
+const swipeSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    targetProfileId: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    action: {
+      type: String,
+      enum: ['like', 'pass'],
+      required: true,
+    },
+  },
+  { timestamps: true }
+);
+
+swipeSchema.index({ userId: 1, targetProfileId: 1 }, { unique: true });
+
+module.exports = mongoose.model('Swipe', swipeSchema);

--- a/back-end/src/routes/eventsRoutes.js
+++ b/back-end/src/routes/eventsRoutes.js
@@ -1,10 +1,36 @@
 const express = require('express');
+const { body } = require('express-validator');
 const router = express.Router();
-const { getAllEvents, getEventById, getUserEvents, createEvent } = require('../controllers/eventsController');
+
+const {
+  getAllEvents,
+  getEventById,
+  getUserEvents,
+  createEvent,
+} = require('../controllers/eventsController');
+const { requireAuth } = require('../middleware/authMiddleware');
+const { validateRequest } = require('../middleware/validateRequest');
 
 router.get('/', getAllEvents);
-router.get('/me', getUserEvents);
+router.get('/me', requireAuth, getUserEvents);
 router.get('/:id', getEventById);
-router.post('/', createEvent);
+
+router.post(
+  '/',
+  requireAuth,
+  [
+    body('title').trim().notEmpty().withMessage('Title is required'),
+    body('description').optional().isString().trim(),
+    body('location').optional().isString().trim(),
+    body('date').optional().isString().trim(),
+    body('time').optional().isString().trim(),
+    body('privacy')
+      .optional()
+      .isIn(['public', 'private'])
+      .withMessage('Privacy must be public or private'),
+  ],
+  validateRequest,
+  createEvent
+);
 
 module.exports = router;

--- a/back-end/src/routes/messagesRoutes.js
+++ b/back-end/src/routes/messagesRoutes.js
@@ -1,10 +1,34 @@
 const express = require('express');
+const { body } = require('express-validator');
 const router = express.Router();
-const { getConversations, getMessages, sendMessage, createConversation } = require('../controllers/messagesController');
 
-router.get('/', getConversations);
-router.post('/', createConversation);
-router.get('/:conversationId', getMessages);
-router.post('/:conversationId', sendMessage);
+const {
+  getConversations,
+  getMessages,
+  sendMessage,
+  createConversation,
+} = require('../controllers/messagesController');
+const { requireAuth } = require('../middleware/authMiddleware');
+const { validateRequest } = require('../middleware/validateRequest');
+
+router.get('/', requireAuth, getConversations);
+
+router.post(
+  '/',
+  requireAuth,
+  [body('otherUserId').notEmpty().withMessage('otherUserId is required')],
+  validateRequest,
+  createConversation
+);
+
+router.get('/:conversationId', requireAuth, getMessages);
+
+router.post(
+  '/:conversationId',
+  requireAuth,
+  [body('text').trim().notEmpty().withMessage('text is required')],
+  validateRequest,
+  sendMessage
+);
 
 module.exports = router;

--- a/back-end/src/routes/swipeRoutes.js
+++ b/back-end/src/routes/swipeRoutes.js
@@ -1,7 +1,23 @@
 const express = require('express');
+const { body } = require('express-validator');
 const router = express.Router();
-const { getProfiles } = require('../controllers/swipeController');
 
-router.get('/profiles', getProfiles);
+const {
+  getProfiles,
+  likeProfile,
+  passProfile,
+  getHistory,
+} = require('../controllers/swipeController');
+const { requireAuth } = require('../middleware/authMiddleware');
+const { validateRequest } = require('../middleware/validateRequest');
+
+const swipeActionValidators = [
+  body('profileId').notEmpty().withMessage('profileId is required'),
+];
+
+router.get('/profiles', requireAuth, getProfiles);
+router.get('/history', requireAuth, getHistory);
+router.post('/like', requireAuth, swipeActionValidators, validateRequest, likeProfile);
+router.post('/pass', requireAuth, swipeActionValidators, validateRequest, passProfile);
 
 module.exports = router;

--- a/back-end/src/services/mockStore.js
+++ b/back-end/src/services/mockStore.js
@@ -6,91 +6,6 @@ const profiles = new Map();
 
 let nextId = 1;
 
-// ── Events mock data ──
-const events = [
-  {
-    id: 'e1',
-    title: 'Intern Sushi Night',
-    description: 'All-you-can-eat sushi with fellow interns in the city!',
-    time: '7:00 PM',
-    date: '2026-05-15',
-    location: '123 Broadway, New York, NY',
-    privacy: 'public',
-    createdBy: 'u1',
-  },
-  {
-    id: 'e2',
-    title: 'Central Park Picnic',
-    description: 'Bring a blanket and snacks — let\'s hang out in the park.',
-    time: '12:00 PM',
-    date: '2026-05-18',
-    location: 'Sheep Meadow, Central Park, NY',
-    privacy: 'public',
-    createdBy: 'u2',
-  },
-  {
-    id: 'e3',
-    title: 'Rooftop Game Night',
-    description: 'Board games, card games, and good vibes on a rooftop.',
-    time: '8:00 PM',
-    date: '2026-05-20',
-    location: '456 W 42nd St, New York, NY',
-    privacy: 'public',
-    createdBy: 'u1',
-  },
-  {
-    id: 'e4',
-    title: 'Coffee & Code',
-    description: 'Casual co-working session at a cafe. Bring your laptop!',
-    time: '10:00 AM',
-    date: '2026-05-22',
-    location: 'Blue Bottle Coffee, Williamsburg, NY',
-    privacy: 'public',
-    createdBy: 'u3',
-  },
-  {
-    id: 'e5',
-    title: 'Sunset Run Club',
-    description: 'Easy 3-mile run along the Hudson River at sunset.',
-    time: '6:30 PM',
-    date: '2026-05-25',
-    location: 'Hudson River Park, Pier 40, NY',
-    privacy: 'public',
-    createdBy: 'u2',
-  },
-  {
-    id: 'e6',
-    title: 'Intern Karaoke Night',
-    description: 'Sing your heart out — no judgment zone!',
-    time: '9:00 PM',
-    date: '2026-05-28',
-    location: '789 St Marks Pl, New York, NY',
-    privacy: 'public',
-    createdBy: 'u3',
-  },
-];
-let nextEventId = 7;
-
-const userEvents = {
-  hosting: [
-    { id: 'h1', title: 'Sushi Night', date: 'June 12' },
-    { id: 'h2', title: 'Movie Night', date: 'June 19' },
-  ],
-  attending: [
-    { id: 'a1', title: 'Central Park Picnic', date: 'June 15' },
-    { id: 'a2', title: 'Rooftop Happy Hour', date: 'June 22' },
-  ],
-  private: [
-    { id: 'p1', title: 'Alex & Friends Dinner', host: 'Alex Chen', date: 'June 14' },
-    { id: 'p2', title: 'Priya Study Session', host: 'Priya S.', date: 'June 17' },
-  ],
-  suggested: [
-    { id: 's1', title: 'Intern Mixer NYC', date: 'June 20' },
-    { id: 's2', title: 'Tech Talk @ WeWork', date: 'June 25' },
-    { id: 's3', title: 'Brooklyn Foodie Tour', date: 'June 28' },
-  ],
-};
-
 // ── Messages mock data ──
 const conversations = [
   {
@@ -234,34 +149,6 @@ function completeProfile(userId) {
   return profile;
 }
 
-// ── Events functions ──
-function getEvents() {
-  return events;
-}
-
-function getEventById(id) {
-  return events.find(e => e.id === id) || null;
-}
-
-function getUserEvents() {
-  return userEvents;
-}
-
-function createEvent({ title, description, location, date, time, privacy }) {
-  const newEvent = {
-    id: 'e' + nextEventId++,
-    title,
-    description: description || '',
-    location: location || '',
-    date: date || '',
-    time: time || '',
-    privacy: privacy || 'public',
-    createdBy: 'u1',
-  };
-  events.unshift(newEvent);
-  return newEvent;
-}
-
 // ── Messages functions ──
 function getConversations() {
   return conversations;
@@ -329,10 +216,6 @@ module.exports = {
   saveProfileStep,
   getProfile,
   completeProfile,
-  getEvents,
-  getEventById,
-  getUserEvents,
-  createEvent,
   getConversations,
   getMessages,
   sendMessage,

--- a/back-end/test/eventsRoutes.test.js
+++ b/back-end/test/eventsRoutes.test.js
@@ -1,55 +1,96 @@
 const chai = require('chai');
 const expect = chai.expect;
 const request = require('supertest');
+const mongoose = require('mongoose');
+const jwt = require('jsonwebtoken');
 const app = require('../src/app');
+const Event = require('../src/models/Event');
 
-describe('Events Routes', () => {
+describe('Events Routes', function () {
+  this.timeout(30000);
+
+  const testUserId = new mongoose.Types.ObjectId();
+  let token;
+  let createdEventId;
+
+  before(async function () {
+    await mongoose.connect(process.env.MONGO_URI);
+    token = jwt.sign({ sub: String(testUserId), email: 'eventtest@test.com' }, process.env.JWT_SECRET, { expiresIn: '1h' });
+  });
+
+  after(async function () {
+    await Event.deleteMany({ createdBy: testUserId });
+    await mongoose.disconnect();
+  });
+
   it('GET /api/events should return an array of events', async () => {
     const res = await request(app).get('/api/events');
     expect(res.status).to.equal(200);
     expect(res.body).to.be.an('array');
-    expect(res.body.length).to.be.greaterThan(0);
-    expect(res.body[0]).to.have.property('title');
-    expect(res.body[0]).to.have.property('id');
   });
 
-  it('GET /api/events/:id should return a single event', async () => {
-    const res = await request(app).get('/api/events/e1');
-    expect(res.status).to.equal(200);
-    expect(res.body).to.have.property('id', 'e1');
-    expect(res.body).to.have.property('title');
+  it('POST /api/events without auth should return 401', async () => {
+    const res = await request(app)
+      .post('/api/events')
+      .send({ title: 'No Auth Event' });
+    expect(res.status).to.equal(401);
   });
 
-  it('GET /api/events/:id should return 404 for unknown id', async () => {
-    const res = await request(app).get('/api/events/e999');
-    expect(res.status).to.equal(404);
+  it('POST /api/events should return 400 without title', async () => {
+    const res = await request(app)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ location: 'NYC' });
+    expect(res.status).to.equal(400);
     expect(res.body).to.have.property('error');
   });
 
   it('POST /api/events should create a new event', async () => {
     const res = await request(app)
       .post('/api/events')
+      .set('Authorization', `Bearer ${token}`)
       .send({ title: 'Test Event', location: 'NYC', date: '2026-06-01', time: '5:00 PM' });
     expect(res.status).to.equal(201);
     expect(res.body).to.have.property('id');
     expect(res.body).to.have.property('title', 'Test Event');
     expect(res.body).to.have.property('location', 'NYC');
+    expect(res.body).to.have.property('privacy', 'public');
+    createdEventId = res.body.id;
+  });
+
+  it('GET /api/events/:id should return a single event', async () => {
+    const res = await request(app).get(`/api/events/${createdEventId}`);
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('id', createdEventId);
+    expect(res.body).to.have.property('title', 'Test Event');
+  });
+
+  it('GET /api/events/:id should return 404 for unknown id', async () => {
+    const res = await request(app).get(`/api/events/${new mongoose.Types.ObjectId()}`);
+    expect(res.status).to.equal(404);
+    expect(res.body).to.have.property('error');
+  });
+
+  it('GET /api/events/:id should return 404 for invalid id format', async () => {
+    const res = await request(app).get('/api/events/not-a-valid-id');
+    expect(res.status).to.equal(404);
+    expect(res.body).to.have.property('error');
+  });
+
+  it('GET /api/events/me without auth should return 401', async () => {
+    const res = await request(app).get('/api/events/me');
+    expect(res.status).to.equal(401);
   });
 
   it('GET /api/events/me should return user events with all categories', async () => {
-    const res = await request(app).get('/api/events/me');
+    const res = await request(app)
+      .get('/api/events/me')
+      .set('Authorization', `Bearer ${token}`);
     expect(res.status).to.equal(200);
     expect(res.body).to.have.property('hosting').that.is.an('array');
     expect(res.body).to.have.property('attending').that.is.an('array');
     expect(res.body).to.have.property('private').that.is.an('array');
     expect(res.body).to.have.property('suggested').that.is.an('array');
-  });
-
-  it('POST /api/events should return 400 without title', async () => {
-    const res = await request(app)
-      .post('/api/events')
-      .send({ location: 'NYC' });
-    expect(res.status).to.equal(400);
-    expect(res.body).to.have.property('error');
+    expect(res.body.hosting.some(e => e.id === createdEventId)).to.equal(true);
   });
 });

--- a/back-end/test/messagesRoutes.test.js
+++ b/back-end/test/messagesRoutes.test.js
@@ -1,92 +1,184 @@
 const chai = require('chai');
 const expect = chai.expect;
 const request = require('supertest');
+const mongoose = require('mongoose');
+const jwt = require('jsonwebtoken');
 const app = require('../src/app');
+const Conversation = require('../src/models/Conversation');
+const User = require('../src/models/User');
 
-describe('Messages Routes', () => {
-  it('GET /api/messages should return an array of conversations', async () => {
+describe('Messages Routes', function () {
+  this.timeout(30000);
+
+  let userA;
+  let userB;
+  let tokenA;
+  let tokenB;
+  let conversationId;
+
+  before(async function () {
+    await mongoose.connect(process.env.MONGO_URI);
+
+    userA = await User.create({
+      email: `msgtest-a-${Date.now()}@test.com`,
+      phone: '+15550000001',
+      verified: true,
+    });
+    userB = await User.create({
+      email: `msgtest-b-${Date.now()}@test.com`,
+      phone: '+15550000002',
+      verified: true,
+    });
+
+    tokenA = jwt.sign({ sub: String(userA._id), email: userA.email }, process.env.JWT_SECRET, { expiresIn: '1h' });
+    tokenB = jwt.sign({ sub: String(userB._id), email: userB.email }, process.env.JWT_SECRET, { expiresIn: '1h' });
+  });
+
+  after(async function () {
+    await Conversation.deleteMany({ participants: { $in: [userA._id, userB._id] } });
+    await User.deleteMany({ _id: { $in: [userA._id, userB._id] } });
+    await mongoose.disconnect();
+  });
+
+  it('GET /api/messages without auth returns 401', async () => {
     const res = await request(app).get('/api/messages');
+    expect(res.status).to.equal(401);
+  });
+
+  it('GET /api/messages returns empty array when no conversations', async () => {
+    const res = await request(app)
+      .get('/api/messages')
+      .set('Authorization', `Bearer ${tokenA}`);
     expect(res.status).to.equal(200);
     expect(res.body).to.be.an('array');
-    expect(res.body.length).to.be.greaterThan(0);
-    expect(res.body[0]).to.have.property('id');
-    expect(res.body[0]).to.have.property('otherUser');
-    expect(res.body[0]).to.have.property('lastMessage');
   });
 
-  it('GET /api/messages/:conversationId should return conversation and messages', async () => {
-    const res = await request(app).get('/api/messages/c1');
-    expect(res.status).to.equal(200);
-    expect(res.body).to.have.property('conversation');
-    expect(res.body).to.have.property('messages');
-    expect(res.body.messages).to.be.an('array');
-    expect(res.body.messages.length).to.be.greaterThan(0);
-  });
-
-  it('GET /api/messages/:conversationId should return 404 for unknown id', async () => {
-    const res = await request(app).get('/api/messages/c999');
-    expect(res.status).to.equal(404);
-    expect(res.body).to.have.property('error');
-  });
-
-  it('POST /api/messages/:conversationId should send a message', async () => {
+  it('POST /api/messages without otherUserId returns 400', async () => {
     const res = await request(app)
-      .post('/api/messages/c1')
-      .send({ text: 'Hello from test!' });
-    expect(res.status).to.equal(201);
-    expect(res.body).to.have.property('id');
-    expect(res.body).to.have.property('sender', 'me');
-    expect(res.body).to.have.property('text', 'Hello from test!');
-  });
-
-  it('POST /api/messages/:conversationId should return 400 without text', async () => {
-    const res = await request(app)
-      .post('/api/messages/c1')
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${tokenA}`)
       .send({});
     expect(res.status).to.equal(400);
     expect(res.body).to.have.property('error');
   });
 
-  it('POST /api/messages should create a new conversation', async () => {
+  it('POST /api/messages with invalid otherUserId returns 400', async () => {
     const res = await request(app)
       .post('/api/messages')
-      .send({ userId: '1', otherUserId: '103' });
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ otherUserId: 'not-a-valid-id' });
+    expect(res.status).to.equal(400);
+  });
+
+  it('POST /api/messages with self as otherUserId returns 400', async () => {
+    const res = await request(app)
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ otherUserId: String(userA._id) });
+    expect(res.status).to.equal(400);
+  });
+
+  it('POST /api/messages with nonexistent user returns 404', async () => {
+    const res = await request(app)
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ otherUserId: String(new mongoose.Types.ObjectId()) });
+    expect(res.status).to.equal(404);
+  });
+
+  it('POST /api/messages creates a conversation', async () => {
+    const res = await request(app)
+      .post('/api/messages')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ otherUserId: String(userB._id) });
     expect(res.status).to.equal(201);
     expect(res.body).to.have.property('id');
-    expect(res.body.otherUser).to.have.property('name', 'Alex');
-    expect(res.body.otherUser).to.have.property('id', '103');
+    expect(res.body.otherUser).to.have.property('id', String(userB._id));
+    conversationId = res.body.id;
   });
 
-  it('POST /api/messages should return 400 if userId is missing', async () => {
+  it('POST /api/messages returns existing conversation on duplicate pair', async () => {
     const res = await request(app)
       .post('/api/messages')
-      .send({ otherUserId: '103' });
-    expect(res.status).to.equal(400);
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ otherUserId: String(userB._id) });
+    expect(res.status).to.equal(201);
+    expect(res.body.id).to.equal(conversationId);
   });
 
-  it('POST /api/messages should return 400 if otherUserId is missing', async () => {
+  it('GET /api/messages returns the conversation for participant', async () => {
     const res = await request(app)
-      .post('/api/messages')
-      .send({ userId: '1' });
-    expect(res.status).to.equal(400);
-  });
-
-  it('POST /api/messages should return existing conversation for duplicate pair', async () => {
-    const first = await request(app)
-      .post('/api/messages')
-      .send({ userId: '1', otherUserId: '104' });
-    const second = await request(app)
-      .post('/api/messages')
-      .send({ userId: '1', otherUserId: '104' });
-    expect(first.body.id).to.equal(second.body.id);
-  });
-
-  it('GET /api/messages/:id should work for a newly created conversation', async () => {
-    const created = await request(app)
-      .post('/api/messages')
-      .send({ userId: '1', otherUserId: '105' });
-    const res = await request(app).get(`/api/messages/${created.body.id}`);
+      .get('/api/messages')
+      .set('Authorization', `Bearer ${tokenA}`);
     expect(res.status).to.equal(200);
-    expect(res.body.messages).to.deep.equal([]);
+    const ids = res.body.map((c) => c.id);
+    expect(ids).to.include(conversationId);
+  });
+
+  it('POST /api/messages/:id without text returns 400', async () => {
+    const res = await request(app)
+      .post(`/api/messages/${conversationId}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({});
+    expect(res.status).to.equal(400);
+    expect(res.body).to.have.property('error');
+  });
+
+  it('POST /api/messages/:id sends a message', async () => {
+    const res = await request(app)
+      .post(`/api/messages/${conversationId}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ text: 'Hello from A' });
+    expect(res.status).to.equal(201);
+    expect(res.body).to.have.property('text', 'Hello from A');
+    expect(res.body).to.have.property('sender', 'me');
+  });
+
+  it('GET /api/messages/:id shows messages with correct sender tags', async () => {
+    await request(app)
+      .post(`/api/messages/${conversationId}`)
+      .set('Authorization', `Bearer ${tokenB}`)
+      .send({ text: 'Hi back from B' });
+
+    const res = await request(app)
+      .get(`/api/messages/${conversationId}`)
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('conversation');
+    expect(res.body).to.have.property('messages').that.is.an('array');
+    expect(res.body.messages).to.have.length.greaterThan(1);
+    const senders = res.body.messages.map((m) => m.sender);
+    expect(senders).to.include('me');
+    expect(senders).to.include('them');
+  });
+
+  it('GET /api/messages/:id returns 403 for non-participant', async () => {
+    const outsider = await User.create({
+      email: `msgtest-outsider-${Date.now()}@test.com`,
+      phone: '+15550000003',
+      verified: true,
+    });
+    const outsiderToken = jwt.sign({ sub: String(outsider._id), email: outsider.email }, process.env.JWT_SECRET, { expiresIn: '1h' });
+
+    const res = await request(app)
+      .get(`/api/messages/${conversationId}`)
+      .set('Authorization', `Bearer ${outsiderToken}`);
+    expect(res.status).to.equal(403);
+
+    await User.deleteOne({ _id: outsider._id });
+  });
+
+  it('GET /api/messages/:id returns 404 for invalid id', async () => {
+    const res = await request(app)
+      .get('/api/messages/not-an-id')
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).to.equal(404);
+  });
+
+  it('GET /api/messages/:id returns 404 for nonexistent id', async () => {
+    const res = await request(app)
+      .get(`/api/messages/${new mongoose.Types.ObjectId()}`)
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).to.equal(404);
   });
 });

--- a/back-end/test/swipeRoutes.test.js
+++ b/back-end/test/swipeRoutes.test.js
@@ -1,36 +1,105 @@
 const chai = require('chai');
 const expect = chai.expect;
 const request = require('supertest');
+const mongoose = require('mongoose');
+const jwt = require('jsonwebtoken');
 const app = require('../src/app');
+const Swipe = require('../src/models/Swipe');
 
-describe('Swipe Routes', () => {
-  it('GET /api/swipe/profiles should return an array of profiles', async () => {
+describe('Swipe Routes', function () {
+  this.timeout(30000);
+
+  const testUserId = new mongoose.Types.ObjectId();
+  let token;
+
+  before(async function () {
+    await mongoose.connect(process.env.MONGO_URI);
+    token = jwt.sign({ sub: String(testUserId), email: 'swipetest@test.com' }, process.env.JWT_SECRET, { expiresIn: '1h' });
+  });
+
+  after(async function () {
+    await Swipe.deleteMany({ userId: testUserId });
+    await mongoose.disconnect();
+  });
+
+  it('GET /api/swipe/profiles without auth returns 401', async () => {
     const res = await request(app).get('/api/swipe/profiles');
+    expect(res.status).to.equal(401);
+  });
+
+  it('GET /api/swipe/profiles returns an array of profiles with auth', async () => {
+    const res = await request(app)
+      .get('/api/swipe/profiles')
+      .set('Authorization', `Bearer ${token}`);
     expect(res.status).to.equal(200);
     expect(res.body).to.be.an('array');
     expect(res.body.length).to.be.greaterThan(0);
     expect(res.body[0]).to.have.property('name');
-    expect(res.body[0]).to.have.property('internshipFull');
-    expect(res.body[0]).to.have.property('age');
-    expect(res.body[0]).to.have.property('swipeImage');
   });
 
-  it('GET /api/swipe/profiles should not include the current user', async () => {
+  it('POST /api/swipe/like without auth returns 401', async () => {
     const res = await request(app)
-      .get('/api/swipe/profiles')
-      .set('x-current-user-id', '101');
-    expect(res.status).to.equal(200);
-    const ids = res.body.map(p => p.id);
-    expect(ids).to.not.include('101');
+      .post('/api/swipe/like')
+      .send({ profileId: '101' });
+    expect(res.status).to.equal(401);
   });
 
-  it('GET /api/swipe/profiles should not include connected users', async () => {
-    // user 1 is connected to user 2 (seeded in connectionsStore)
+  it('POST /api/swipe/like without profileId returns 400', async () => {
+    const res = await request(app)
+      .post('/api/swipe/like')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+    expect(res.status).to.equal(400);
+    expect(res.body).to.have.property('error');
+  });
+
+  it('POST /api/swipe/like records a like', async () => {
+    const res = await request(app)
+      .post('/api/swipe/like')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ profileId: '101' });
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('action', 'like');
+    expect(res.body).to.have.property('targetProfileId', '101');
+  });
+
+  it('POST /api/swipe/pass records a pass', async () => {
+    const res = await request(app)
+      .post('/api/swipe/pass')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ profileId: '102' });
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('action', 'pass');
+    expect(res.body).to.have.property('targetProfileId', '102');
+  });
+
+  it('GET /api/swipe/profiles filters out already-swiped profiles', async () => {
     const res = await request(app)
       .get('/api/swipe/profiles')
-      .set('x-current-user-id', '1');
+      .set('Authorization', `Bearer ${token}`);
     expect(res.status).to.equal(200);
-    const ids = res.body.map(p => p.id);
-    expect(ids).to.not.include('2');
+    const returnedIds = res.body.map((p) => String(p.id));
+    expect(returnedIds).to.not.include('101');
+    expect(returnedIds).to.not.include('102');
+  });
+
+  it('GET /api/swipe/history returns this user\'s swipe actions', async () => {
+    const res = await request(app)
+      .get('/api/swipe/history')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).to.equal(200);
+    expect(res.body).to.be.an('array');
+    const ids = res.body.map((s) => s.targetProfileId);
+    expect(ids).to.include('101');
+    expect(ids).to.include('102');
+  });
+
+  it('POST /api/swipe/like is idempotent (same profile twice)', async () => {
+    const res = await request(app)
+      .post('/api/swipe/like')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ profileId: '101' });
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('action', 'like');
   });
 });

--- a/front-end/src/context/EventsContext.jsx
+++ b/front-end/src/context/EventsContext.jsx
@@ -1,4 +1,5 @@
 import { createContext, useState, useEffect } from 'react'
+import { getToken } from '../utils/auth'
 
 export const EventsContext = createContext()
 
@@ -13,13 +14,23 @@ export function EventsProvider({ children }) {
   }, [])
 
   const addEvent = (newEvent) => {
+    const token = getToken()
     fetch('/api/events', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
       body: JSON.stringify(newEvent),
     })
       .then(res => res.json())
-      .then(created => setEvents(prev => [created, ...prev]))
+      .then(created => {
+        if (created && created.id) {
+          setEvents(prev => [created, ...prev])
+        } else {
+          console.error('Create event failed:', created)
+        }
+      })
       .catch(err => console.error('Failed to create event:', err))
   }
 

--- a/front-end/src/pages/DirectMessagePage.jsx
+++ b/front-end/src/pages/DirectMessagePage.jsx
@@ -1,5 +1,11 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { getToken } from "../utils/auth";
+
+function authHeaders() {
+  const token = getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
 
 export default function DirectMessagePage() {
   const navigate = useNavigate();
@@ -9,11 +15,13 @@ export default function DirectMessagePage() {
   const [newText, setNewText] = useState("");
 
   useEffect(() => {
-    fetch(`/api/messages/${id}`)
+    fetch(`/api/messages/${id}`, { headers: authHeaders() })
       .then(res => res.json())
       .then(data => {
-        setConversation(data.conversation);
-        setMessages(data.messages);
+        if (data && data.conversation) {
+          setConversation(data.conversation);
+          setMessages(data.messages || []);
+        }
       })
       .catch(err => console.error('Failed to fetch messages:', err));
   }, [id]);
@@ -24,13 +32,15 @@ export default function DirectMessagePage() {
 
     fetch(`/api/messages/${id}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify({ text: newText }),
     })
       .then(res => res.json())
       .then(msg => {
-        setMessages(prev => [...prev, msg]);
-        setNewText("");
+        if (msg && msg.id) {
+          setMessages(prev => [...prev, msg]);
+          setNewText("");
+        }
       })
       .catch(err => console.error('Failed to send message:', err));
   };

--- a/front-end/src/pages/MessagesPage.jsx
+++ b/front-end/src/pages/MessagesPage.jsx
@@ -1,15 +1,21 @@
 import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import ConversationList from "../components/ConversationList";
+import { getToken } from "../utils/auth";
 
 export default function MessagesPage() {
   const [conversations, setConversations] = useState([]);
   const location = useLocation();
 
   useEffect(() => {
-    fetch('/api/messages')
+    const token = getToken();
+    fetch('/api/messages', {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    })
       .then(res => res.json())
-      .then(data => setConversations(data))
+      .then(data => {
+        if (Array.isArray(data)) setConversations(data);
+      })
       .catch(err => console.error('Failed to fetch conversations:', err));
   }, [location.key]);
 

--- a/front-end/src/pages/SwipePage.jsx
+++ b/front-end/src/pages/SwipePage.jsx
@@ -1,6 +1,12 @@
 import { useState, useEffect, useContext } from 'react'
 import { ConnectionsContext } from '../context/ConnectionsContext'
+import { getToken } from '../utils/auth'
 import './SwipePage.css'
+
+function authHeaders() {
+  const token = getToken()
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
 
 function SwipePage() {
   const { pending, sent, sendRequest, acceptRequest, rejectRequest } = useContext(ConnectionsContext)
@@ -12,9 +18,11 @@ function SwipePage() {
   const [requestsTab, setRequestsTab] = useState('received')
 
   useEffect(() => {
-    fetch('/api/swipe/profiles')
+    fetch('/api/swipe/profiles', { headers: authHeaders() })
       .then(res => res.json())
-      .then(data => setProfiles(data))
+      .then(data => {
+        if (Array.isArray(data)) setProfiles(data)
+      })
       .catch(err => console.error('Failed to fetch profiles:', err))
   }, [])
 
@@ -24,7 +32,7 @@ function SwipePage() {
     setSwipeDirection('left')
     fetch('/api/swipe/pass', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
       body: JSON.stringify({ profileId: profile.id }),
     }).catch(err => console.error('Failed to pass:', err))
 
@@ -42,6 +50,12 @@ function SwipePage() {
   const handleAccept = () => {
     setSwipeDirection('right')
     setNotification({ type: 'success', text: `✓ Friend request sent to ${profile.name}!` })
+
+    fetch('/api/swipe/like', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify({ profileId: profile.id }),
+    }).catch(err => console.error('Failed to record like:', err))
 
     sendRequest(String(profile.id))
       .catch(err => console.error('Failed to send request:', err))

--- a/front-end/src/pages/YourEventsPage.jsx
+++ b/front-end/src/pages/YourEventsPage.jsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { getToken } from '../utils/auth'
 import './YourEventsPage.css'
 
 export default function YourEventsPage() {
@@ -8,9 +9,14 @@ export default function YourEventsPage() {
   const [data, setData] = useState({ hosting: [], attending: [], private: [], suggested: [] })
 
   useEffect(() => {
-    fetch('/api/events/me')
+    const token = getToken()
+    fetch('/api/events/me', {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    })
       .then(res => res.json())
-      .then(d => setData(d))
+      .then(d => {
+        if (d && d.hosting) setData(d)
+      })
       .catch(err => console.error('Failed to fetch your events:', err))
   }, [])
 


### PR DESCRIPTION
- Events: rewrite controller to use Mongoose Event model, add requireAuth on POST /events and GET /events/me, add express-validator on POST, remove events mock data from mockStore
- Swipe: add new Swipe Mongoose model for tracking like/pass actions, rewrite controller to filter profiles by swipe history, protect all routes with requireAuth, add validation on like/pass
- Messages: rewrite controller to use Mongoose Conversation model with embedded message subdocs, add requireAuth on all routes, add validation on send/create, add POST /messages to create conversation between two real users
