### PR TITLE
Track unread message counts per user per conversation

### DIFF
--- a/back-end/src/controllers/messagesController.js
+++ b/back-end/src/controllers/messagesController.js
@@ -59,10 +59,8 @@ async function getUnreadCount(req, res, next) {
   try {
     const userId = req.auth.userId;
     const myObjectId = new mongoose.Types.ObjectId(userId);
-    const count = await Conversation.countDocuments({
-      participants: myObjectId,
-      lastMessage: { $ne: '' },
-    });
+    const convos = await Conversation.find({ participants: myObjectId }).lean();
+    const count = convos.reduce((sum, c) => sum + (c.unreadCounts?.[userId] || 0), 0);
     return res.status(200).json({ count });
   } catch (err) {
     return next(err);
@@ -89,7 +87,7 @@ async function getConversations(req, res, next) {
           otherUser,
           lastMessage: c.lastMessage || '',
           timestamp: formatTimestamp(c.lastMessageAt || c.updatedAt),
-          unreadCount: 0,
+          unreadCount: c.unreadCounts?.[userId] || 0,
         };
       })
     );
@@ -120,6 +118,10 @@ async function getMessages(req, res, next) {
     if (!isParticipant) {
       return res.status(403).json({ error: 'Not a participant in this conversation' });
     }
+
+    await Conversation.findByIdAndUpdate(conversationId, {
+      $set: { [`unreadCounts.${userId}`]: 0 },
+    });
 
     const otherUserId = (convo.participants || []).find(
       (p) => String(p) !== String(userId)
@@ -177,6 +179,12 @@ async function sendMessage(req, res, next) {
     convo.messages.push(message);
     convo.lastMessage = text;
     convo.lastMessageAt = new Date();
+    for (const participantId of convo.participants) {
+      if (String(participantId) !== String(userId)) {
+        const key = String(participantId);
+        convo.unreadCounts.set(key, (convo.unreadCounts.get(key) || 0) + 1);
+      }
+    }
     await convo.save();
 
     const saved = convo.messages[convo.messages.length - 1];

--- a/back-end/src/models/Conversation.js
+++ b/back-end/src/models/Conversation.js
@@ -24,6 +24,7 @@ const conversationSchema = new mongoose.Schema(
     messages: [messageSchema],
     lastMessage: { type: String, default: '' },
     lastMessageAt: { type: Date },
+    unreadCounts: { type: Map, of: Number, default: {} },
   },
   { timestamps: true }
 );

--- a/back-end/test/messagesRoutes.test.js
+++ b/back-end/test/messagesRoutes.test.js
@@ -170,13 +170,27 @@ describe('Messages Routes', function () {
     expect(res.status).to.equal(401);
   });
 
-  it('GET /api/messages/unread/count returns a numeric count', async () => {
+  it('GET /api/messages/unread/count returns correct count for recipient', async () => {
+    // tokenA read the conversation earlier, resetting their count to 0
+    // tokenB received tokenA's message and has not read yet, so count should be >= 1
     const res = await request(app)
       .get('/api/messages/unread/count')
-      .set('Authorization', `Bearer ${tokenA}`);
+      .set('Authorization', `Bearer ${tokenB}`);
     expect(res.status).to.equal(200);
     expect(res.body).to.have.property('count').that.is.a('number');
     expect(res.body.count).to.be.at.least(1);
+  });
+
+  it('reading a conversation resets the unread count to 0', async () => {
+    await request(app)
+      .get(`/api/messages/${conversationId}`)
+      .set('Authorization', `Bearer ${tokenB}`);
+
+    const res = await request(app)
+      .get('/api/messages/unread/count')
+      .set('Authorization', `Bearer ${tokenB}`);
+    expect(res.status).to.equal(200);
+    expect(res.body.count).to.equal(0);
   });
 
   it('POST /api/messages/:id rejects text over 2000 characters', async () => {


### PR DESCRIPTION
added unreadCounts to conversation.js so we can track unread msg counts for a user, adds other variables to track when users have opened a msg / how many they have unread, so the badge in conversationlist is not hardcoded anymore. added some tests