### PR TITLE
exclude password from ProfileContext localStorage persistence

### DIFF
--- a/front-end/src/context/ProfileContext.jsx
+++ b/front-end/src/context/ProfileContext.jsx
@@ -151,7 +151,8 @@ export function ProfileProvider({ children }) {
   }, [])
 
   useEffect(() => {
-    localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(data))
+    const { password: _pw, ...accountSafe } = data.account
+    localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify({ ...data, account: accountSafe }))
   }, [data])
 
   const updateAccount = (accountUpdates) => {


### PR DESCRIPTION
Stops profile context from saving the password to local storage - as this is a security issue